### PR TITLE
line endings!

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -12,11 +12,16 @@ def execute_cmd(cmd, capture=False, **kwargs):
     proc = subprocess.Popen(cmd, **kwargs)
 
     if not capture:
+        # not capturing output, let the subprocesses talk directly to the terminal
         ret = proc.wait()
         if ret != 0:
             raise subprocess.CalledProcessError(ret, cmd)
         return
     
+    # Capture output for logging.
+    # Each line will be yielded as text.
+    # This should behave the same as .readline(), but splits on `\r` OR `\n`,
+    # not just `\n`.
     buf = []
     def flush():
         line = b''.join(buf).decode('utf8', 'replace')

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -1,14 +1,24 @@
 import subprocess
 
-def execute_cmd(cmd, **kwargs):
+def execute_cmd(cmd, capture=False, **kwargs):
     """
-    Call given command, yielding output line by line
+    Call given command, yielding output line by line if capture=True
     """
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, **kwargs)
+    if capture:
+        kwargs['stdout'] = subprocess.PIPE
+        kwargs['stderr'] = subprocess.STDOUT
+
+    proc = subprocess.Popen(cmd, **kwargs)
+
+    if not capture:
+        ret = proc.wait()
+        if ret != 0:
+            raise subprocess.CalledProcessError(ret, cmd)
+        return
 
     try:
-        for line in iter(proc.stdout.readline, ''):
-            yield line.rstrip()
+        for line in iter(proc.stdout.readline, b''):
+            yield line.decode('utf8', 'replace')
     finally:
         ret = proc.wait()
         if ret != 0:


### PR DESCRIPTION
- only capture subprocess output when doing json logging
- opt-in to json logging with `--json-logs`
- don't strip line endings in captured log messages (needed for distinguishing between CR and LF)
- yield lines that end with CR (needed for live-updating CR-style progress bars)