### PR TITLE
add LegacyBinderDockerfile buildpack

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -24,7 +24,10 @@ from docker.utils import kwargs_from_env
 
 import subprocess
 
-from .detectors import BuildPack, PythonBuildPack, DockerBuildPack, CondaBuildPack
+from .detectors import (
+    BuildPack, PythonBuildPack, DockerBuildPack, LegacyBinderDockerBuildPack,
+    CondaBuildPack,
+)
 from .utils import execute_cmd
 from . import __version__
 
@@ -90,7 +93,7 @@ class Repo2Docker(Application):
 
     buildpacks = List(
         Type(BuildPack),
-        [DockerBuildPack, CondaBuildPack, PythonBuildPack],
+        [LegacyBinderDockerBuildPack, DockerBuildPack, CondaBuildPack, PythonBuildPack],
         config=True,
         help="""
         Ordered list of BuildPacks to try to use to build a git repository.

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -45,7 +45,12 @@ class DockerBuildPack(BuildPack):
                 decode=True
         ):
             if 'stream' in progress:
-                self.log.info(progress['stream'], extra=dict(phase='building'))
+                if self.capture:
+                    self.log.info(progress['stream'], extra=dict(phase='building'))
+                else:
+                    sys.stdout.write(progress['stream'])
+
+_legacybinder_docker_appendix = """
 
 
 class S2IBuildPack(BuildPack):

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 
 import docker
+from docker.utils import kwargs_from_env
 
 from traitlets import Unicode, Dict, Bool
 from traitlets.config import LoggingConfigurable
@@ -37,7 +38,7 @@ class DockerBuildPack(BuildPack):
         return os.path.exists(os.path.join(workdir, 'Dockerfile'))
 
     def build(self, workdir, ref, output_image_spec):
-        client = docker.APIClient(base_url='unix://var/run/docker.sock', version='auto')
+        client = docker.APIClient(version='auto', **kwargs_from_env())
         for progress in client.build(
                 path=workdir,
                 tag=output_image_spec,

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+from textwrap import dedent
 
 import docker
 from docker.utils import kwargs_from_env
@@ -50,26 +51,27 @@ class DockerBuildPack(BuildPack):
                 else:
                     sys.stdout.write(progress['stream'])
 
-_legacy_binder_docker_appendix = """
-USER root
-COPY . /home/main/notebooks
-RUN chown -R main:main /home/main/notebooks
-USER main
-WORKDIR /home/main/notebooks
-ENV PATH /home/main/anaconda2/envs/python3/bin:$PATH
-RUN conda install -n python3 notebook==5.0.0 ipykernel==4.6.0 && \
-    pip install jupyterhub==0.7.2 && \
-    conda remove -n python3 nb_conda_kernels && \
-    conda install -n root ipykernel==4.6.0 && \
-    /home/main/anaconda2/envs/python3/bin/ipython kernel install --sys-prefix && \
-    /home/main/anaconda2/bin/ipython kernel install --prefix=/home/main/anaconda2/envs/python3
-ENV JUPYTER_PATH /home/main/anaconda2/share/jupyter:$JUPYTER_PATH
-CMD jupyter notebook --ip 0.0.0.0
-"""
 
 class LegacyBinderDockerBuildPack(DockerBuildPack):
     
     name = Unicode('Legacy Binder Dockerfile')
+    dockerfile_appendix = Unicode(dedent(r"""
+    USER root
+    COPY . /home/main/notebooks
+    RUN chown -R main:main /home/main/notebooks
+    USER main
+    WORKDIR /home/main/notebooks
+    ENV PATH /home/main/anaconda2/envs/python3/bin:$PATH
+    RUN conda install -n python3 notebook==5.0.0 ipykernel==4.6.0 && \
+        pip install jupyterhub==0.7.2 && \
+        conda remove -n python3 nb_conda_kernels && \
+        conda install -n root ipykernel==4.6.0 && \
+        /home/main/anaconda2/envs/python3/bin/ipython kernel install --sys-prefix && \
+        /home/main/anaconda2/bin/ipython kernel install --prefix=/home/main/anaconda2/envs/python3
+    ENV JUPYTER_PATH /home/main/anaconda2/share/jupyter:$JUPYTER_PATH
+    CMD jupyter notebook --ip 0.0.0.0
+    """), config=True)
+    
     def detect(self, workdir):
         dockerfile = os.path.join(workdir, 'Dockerfile')
         if not os.path.exists(dockerfile):
@@ -86,8 +88,9 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
         return False
 
     def amend_dockerfile(self, dockerfile):
+        print(self.dockerfile_appendix)
         with open(dockerfile, 'a') as f:
-            f.write(_legacy_binder_docker_appendix)
+            f.write(self.dockerfile_appendix)
 
 
 class S2IBuildPack(BuildPack):


### PR DESCRIPTION
only run on dockerfiles with `FROM andrewosh/binder-base`

- installs required versions of ipykernel, jupyterhub, notebook
- registers kernelspecs explicitly
- launches notebook server with python3 env
- removes nb_conda_kernels, which was causing trouble when not launched from the root env
- sets JUPYTER_PATH so kernelspecs and extensions that were being installed into the python 2 env should still be picked up