### PR TITLE
tweak how the python2 kerenl is installed

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -68,7 +68,8 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
         conda remove -n python3 nb_conda_kernels && \
         conda install -n root ipykernel==4.6.0 && \
         /home/main/anaconda2/envs/python3/bin/ipython kernel install --sys-prefix && \
-        /home/main/anaconda2/bin/ipython kernel install --prefix=/home/main/anaconda2/envs/python3
+        /home/main/anaconda2/bin/ipython kernel install --prefix=/home/main/anaconda2/envs/python3 && \
+        /home/main/anaconda2/bin/ipython kernel install --sys-prefix
     ENV JUPYTER_PATH /home/main/anaconda2/share/jupyter:$JUPYTER_PATH
     CMD jupyter notebook --ip 0.0.0.0
     """), config=True)


### PR DESCRIPTION
install in its own prefix as well

Python 2 notebooks were running with Python 3 due to a bad kernelspec