### PR TITLE
adding doc generation from the tests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -183,3 +183,28 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+# Build the repo2docker test syntax
+from glob import glob
+import os
+s = ''
+for folder, _, files in os.walk(os.path.join('..', '..', 'tests')):
+    if 'README.rst' not in files:
+        continue
+    header = files.pop(files.index('README.rst'))
+    with open(os.path.join(folder, header), 'r') as ff:
+        s += ff.read() + '\n'
+    for ifile in files:
+        filename = os.path.basename(ifile)
+        if filename == 'verify':
+            continue
+        with open(os.path.join(folder, ifile), 'r') as ff:
+            lines = ff.readlines()
+        lines = ['   ' + line for line in lines]
+        this_s = '``{}``\n{}\n\n**Contents**::\n\n'.format(
+            filename, '~' * (len(filename) + 4))
+        this_s += '\n'.join(lines)
+        this_s += '\n\n'
+        s += this_s
+with open('./generated/test_file_text.txt', 'w') as ff:
+    ff.write(s)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,3 +18,8 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+Build Syntax
+============
+
+.. include:: generated/test_file_text.txt

--- a/tests/conda/requirements/README.rst
+++ b/tests/conda/requirements/README.rst
@@ -1,0 +1,5 @@
+Python - Mixed Requirements
+---------------------------
+
+You can specify both a ``requirements.txt`` and an ``environment.yml`` file,
+and both of these will be used to build your environment.

--- a/tests/conda/simple/README.rst
+++ b/tests/conda/simple/README.rst
@@ -1,0 +1,5 @@
+Python - Conda Environment
+--------------------------
+
+Conda environments files may allow for more complex builds and dependencies. You
+can specify them in the standard YAML structure.

--- a/tests/julia/pyplot/README.rst
+++ b/tests/julia/pyplot/README.rst
@@ -1,0 +1,5 @@
+Julia - REQUIRE
+---------------
+
+The simplest way to specify dependencies in Julia, a REQUIRE file simply
+lists the names of packages. Each one will be installed but not pre-compiled.


### PR DESCRIPTION
This is a quick first-stab at auto-generating some documentation from our tests. It requires that there is a `README.rst` file inside any of the folders that we want to document. If it finds this file, then it adds a section that includes whatever is inside `README.rst` for that folder, and then shows the contents of the other files in that folder.

I added the readme file for a few sample repos so we can see how it looks. For some reason github isn't serving my website now so it's hard for me to show you, but here's a screenshot of what it looks like:

![image](https://user-images.githubusercontent.com/1839645/28808917-c3fa79e8-764d-11e7-8995-30de1018c299.png)

