### PR TITLE
Add --debug & --no-build options

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -145,8 +145,8 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
-            '--print-dockerfile',
-            help="Print dockerfile contents to stdout",
+            '--debug',
+            help="Turn on debug logging",
             action='store_true',
         )
 
@@ -181,6 +181,9 @@ class Repo2Docker(Application):
 
     def initialize(self):
         args = self.get_argparser().parse_args()
+
+        if args.debug:
+            self.log_level = logging.DEBUG
 
         self.load_config_file(args.config)
 
@@ -223,7 +226,6 @@ class Repo2Docker(Application):
         self.run = args.run
         self.json_logs = args.json_logs
 
-        self.print_dockerfile = args.print_dockerfile
         self.build = args.build
         if not self.build:
             # Can't push nor run if we aren't building
@@ -316,8 +318,7 @@ class Repo2Docker(Application):
                 picked_buildpack = bp
                 break
 
-        if self.print_dockerfile:
-            self.log.info(picked_buildpack.render(), extra=dict(phase='building'))
+        self.log.debug(picked_buildpack.render(), extra=dict(phase='building'))
 
         if self.build:
             self.log.info('Using %s builder\n', bp.name, extra=dict(phase='building'))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from setuptools import setup, find_packages
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyter-repo2docker',
-    version='0.3',
+    version='0.4',
     install_requires=[
         'docker',
         'traitlets',


### PR DESCRIPTION
If --debug is passed, it'll print the Dockerfile generated. 

Note that  the Dockefile thus produced is *not* in any way usefu outside of debuggingl -
we do a bunch of path munging and adding scripts in here (such as install-miniconda).
If it isn't useful as is now, I don't think we should encourage people to use this to print 
Dockerfiles for basing their Dockerfiles on from here, and should just write that as docs
instead.

Either way, this is still very useful for Debugging.