### PR TITLE
don't install requirements.txt if environment.yml is present

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -554,7 +554,7 @@ class CondaBuildPack(BuildPack):
                 conda clean -tipsy
                 """
             ))
-        if os.path.exists('requirements.txt'):
+        elif os.path.exists('requirements.txt'):
             assembly_scripts.append((
                 '${NB_USER}',
                 'pip install --no-cache-dir -r requirements.txt'

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -554,11 +554,6 @@ class CondaBuildPack(BuildPack):
                 conda clean -tipsy
                 """
             ))
-        elif os.path.exists('requirements.txt'):
-            assembly_scripts.append((
-                '${NB_USER}',
-                'pip install --no-cache-dir -r requirements.txt'
-            ))
         return assembly_scripts
 
     def detect(self):

--- a/tests/conda/requirements/README.rst
+++ b/tests/conda/requirements/README.rst
@@ -1,8 +1,8 @@
-Python - Mixed Requirements
----------------------------
+Conda - Mixed Requirements
+--------------------------
 
 An ``environment.yml`` takes precedence over ``requirements.txt``.
-To install files into a conda environment with pip, use the ``pip`` key in ``environment.yml``:
+To install Python packages into a conda environment with pip, use the ``pip`` key in ``environment.yml``:
 
 .. sourcecode:: yaml
 

--- a/tests/conda/requirements/README.rst
+++ b/tests/conda/requirements/README.rst
@@ -1,5 +1,12 @@
 Python - Mixed Requirements
 ---------------------------
 
-You can specify both a ``requirements.txt`` and an ``environment.yml`` file,
-and both of these will be used to build your environment.
+An ``environment.yml`` takes precedence over ``requirements.txt``.
+To install files into a conda environment with pip, use the ``pip`` key in ``environment.yml``:
+
+.. sourcecode:: yaml
+
+    dependencies:
+      - numpy
+      - pip:
+        - tornado

--- a/tests/conda/requirements/environment.yml
+++ b/tests/conda/requirements/environment.yml
@@ -1,2 +1,4 @@
 dependencies:
   - numpy
+  - pip:
+    - simplejson

--- a/tests/conda/requirements/verify
+++ b/tests/conda/requirements/verify
@@ -4,4 +4,9 @@ import sys
 assert sys.version_info[:2] == (3, 6)
 
 import numpy
-import there
+try:
+    import there
+except ImportError:
+    print('ok')
+else:
+    raise Exception("'there' shouldn't have been installed from requirements.txt")

--- a/tests/conda/requirements/verify
+++ b/tests/conda/requirements/verify
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import sys
 
-assert sys.version_info[:2] == (3, 6)
+assert sys.version_info[:2] == (3, 6), sys.version
 
 import numpy
 try:
     import there
 except ImportError:
-    print('ok')
+    pass
 else:
     raise Exception("'there' shouldn't have been installed from requirements.txt")

--- a/tests/conda/simple/README.rst
+++ b/tests/conda/simple/README.rst
@@ -1,5 +1,5 @@
-Python - Conda Environment
---------------------------
+Conda Environment
+-----------------
 
 Conda environments files may allow for more complex builds and dependencies. You
-can specify them in the standard YAML structure.
+can specify them in the standard `environment.yml` files.

--- a/tests/conda/simple/verify
+++ b/tests/conda/simple/verify
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
 
-assert sys.version_info[:2] == (3, 6)
+assert sys.version_info[:2] == (3, 6), sys.version
 
 import numpy


### PR DESCRIPTION
The most likely cause of both being present is equivalent dependencies for pip and conda users, not a single multi-stage conda environment.

If deps should be installed in conda with pip, they should be in `environment.yml` under `pip`.