### PR TITLE
make JUPYTERHUB_VERSION a build arg

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -33,13 +33,13 @@ from .utils import execute_cmd
 from . import __version__
 
 
-def c(args):
+def compose(buildpacks, parent=None):
     """
     Shortcut to compose many buildpacks together
     """
-    image = args[0]()
-    for arg in args[1:]:
-        image = image.compose_with(arg())
+    image = buildpacks[0](parent=parent)
+    for buildpack in buildpacks[1:]:
+        image = image.compose_with(buildpack(parent=parent))
     return image
 
 
@@ -310,10 +310,10 @@ class Repo2Docker(Application):
             )
 
         os.chdir(checkout_path)
-        picked_buildpack = c(self.default_buildpack)
+        picked_buildpack = compose(self.default_buildpack, parent=self)
 
         for bp_spec in self.buildpacks:
-            bp = c(bp_spec)
+            bp = compose(bp_spec, parent=self)
             if bp.detect():
                 picked_buildpack = bp
                 break

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -149,8 +149,12 @@ class BuildPack(LoggingConfigurable):
         and the Hub itself should have the same version number.
         """
     )
+    @default('jupyterhub_version')
+    def _jupyterhub_version_default(self):
+        """Allow setting JUPYTERHUB_VERSION via env"""
+        return os.environ.get('JUPYTERHUB_VERSION') or '0.7.2'
+
     packages = Set(
-        set(),
         help="""
         List of packages that are installed in this BuildPack by default.
 

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -707,6 +707,7 @@ class JuliaBuildPack(BuildPack):
 
 class DockerBuildPack(BuildPack):
     name = "Dockerfile"
+    dockerfile = "Dockerfile"
 
     def detect(self):
         return os.path.exists('Dockerfile')
@@ -719,6 +720,7 @@ class DockerBuildPack(BuildPack):
         client = docker.APIClient(version='auto', **docker.utils.kwargs_from_env())
         for line in client.build(
                 path=os.getcwd(),
+                dockerfile=self.dockerfile,
                 tag=image_spec,
                 buildargs={
                     'JUPYTERHUB_VERSION': self.jupyterhub_version,
@@ -730,6 +732,7 @@ class DockerBuildPack(BuildPack):
 class LegacyBinderDockerBuildPack(DockerBuildPack):
 
     name = 'Legacy Binder Dockerfile'
+    dockerfile = '._binder.Dockerfile'
 
     dockerfile_appendix = Unicode(dedent(r"""
     USER root
@@ -753,6 +756,11 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
     def render(self):
         with open('Dockerfile') as f:
             return f.read() + self.dockerfile_appendix
+
+    def build(self, image_spec):
+        with open(self.dockerfile, 'w') as f:
+            f.write(self.render())
+        return super().build(image_spec)
 
     def detect(self):
         try:

--- a/repo2docker/files/conda/environment.yml
+++ b/repo2docker/files/conda/environment.yml
@@ -5,5 +5,3 @@ dependencies:
   - ipykernel==4.6.0
   - ipywidgets==6.0.0
   - jupyterlab==0.22.1
-  - pip:
-    - jupyterhub==0.7.2

--- a/repo2docker/files/conda/install-miniconda.bash
+++ b/repo2docker/files/conda/install-miniconda.bash
@@ -30,6 +30,7 @@ ${CONDA_DIR}/bin/conda config --system --set update_dependencies false
 ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true
 
 ${CONDA_DIR}/bin/conda env update -n root -f /tmp/environment.yml
+${CONDA_DIR}/bin/pip install --no-cache-dir jupyterhub==${JUPYTERHUB_VERSION}
 # Clean things out!
 ${CONDA_DIR}/bin/conda clean -tipsy
 

--- a/tests/dockerfile/jupyter-stack/Dockerfile
+++ b/tests/dockerfile/jupyter-stack/Dockerfile
@@ -1,4 +1,7 @@
 FROM jupyter/base-notebook:b4dd11e16ae4
 
+ARG JUPYTERHUB_VERSION
+RUN pip install jupyterhub==$JUPYTERHUB_VERSION
+
 RUN pip install there
 ADD verify verify

--- a/tests/dockerfile/jupyter-stack/verify
+++ b/tests/dockerfile/jupyter-stack/verify
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+import os
 import sys
 
 assert sys.version_info[:2] == (3, 6)
 
 import jupyter
+import jupyterhub
 import there

--- a/tests/dockerfile/legacy/verify
+++ b/tests/dockerfile/legacy/verify
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+import os
 import sys
 
-assert sys.version_info[:2] == (2, 7)
+assert sys.version_info[:2] == (3, 5), sys.version
 
 import jupyter
+import jupyterhub

--- a/tests/dockerfile/simple/Dockerfile
+++ b/tests/dockerfile/simple/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.5
+FROM python:3.5
+
+ARG JUPYTERHUB_VERSION
+RUN pip3 install jupyterhub==$JUPYTERHUB_VERSION
 
 ENTRYPOINT "/bin/sh"
 


### PR DESCRIPTION
and respect it in all buildpacks

We probably want to eventually do the same for every other package with a hardcoded version (notebook, ipython, etc.).

In testing, I also noticed that Legacy Dockerfile isn't working at all right now because the dockerfile_appendix is ignored.

The new tests here revealed this and ought to now be fixed.