### PR TITLE
More forgiving rmtree

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -334,7 +334,7 @@ class Repo2Docker(Application):
                     self.log.info(json.dumps(l), extra=dict(phase='building'))
 
         if self.cleanup_checkout:
-            shutil.rmtree(checkout_path)
+            shutil.rmtree(checkout_path, ignore_errors=True)
 
         if self.push:
             self.push_image()


### PR DESCRIPTION
rmtree throws exceptions on a git repo checked out on a Windows filesystem. I believe that ignoring errors is ok here as app.py fully controls the checkout dir.