### PR TITLE
Update JupyterLab to 0.27

### DIFF
--- a/repo2docker/files/conda/environment.yml
+++ b/repo2docker/files/conda/environment.yml
@@ -4,4 +4,4 @@ dependencies:
   - ipython==6.0.0
   - ipykernel==4.6.0
   - ipywidgets==6.0.0
-  - jupyterlab==0.22.1
+  - jupyterlab==0.27


### PR DESCRIPTION
How would we run commands to install JupyterLab packages which require running bash commands such as `jupyter labextension install foo`? @blink1073