### PR TITLE
Look in .binder directory for files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ build
 __pycache__
 MANIFEST
 
+.DS_Store
+.cache
+
 repo2docker/s2i
 
 ^bin/

--- a/tests/conda/binder-dir/.binder/environment.yml
+++ b/tests/conda/binder-dir/.binder/environment.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - numpy

--- a/tests/conda/binder-dir/Dockerfile
+++ b/tests/conda/binder-dir/Dockerfile
@@ -1,0 +1,2 @@
+FROM doesntmatter
+# this file should be ignored because there's a .binder dir

--- a/tests/conda/binder-dir/README.rst
+++ b/tests/conda/binder-dir/README.rst
@@ -1,0 +1,4 @@
+Binder Directory
+----------------
+
+top-level Dockerfile will be ignored if .binder/environment.yml exists.

--- a/tests/conda/binder-dir/environment.yml
+++ b/tests/conda/binder-dir/environment.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - thiswontwork
+  invalid

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import sys
+
+assert sys.version_info[:2] == (3, 6), sys.version
+
+import numpy

--- a/tests/dockerfile/binder-dir/.binder/Dockerfile
+++ b/tests/dockerfile/binder-dir/.binder/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.5
+
+ARG JUPYTERHUB_VERSION
+RUN pip3 install jupyterhub==$JUPYTERHUB_VERSION
+
+ENTRYPOINT "/bin/sh"
+
+ADD sayhi.sh /usr/local/bin/sayhi.sh
+ADD verify verify

--- a/tests/dockerfile/binder-dir/Dockerfile
+++ b/tests/dockerfile/binder-dir/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.5
+
+RUN exit 1

--- a/tests/dockerfile/binder-dir/README.rst
+++ b/tests/dockerfile/binder-dir/README.rst
@@ -1,0 +1,4 @@
+Binder Directory
+----------------
+
+top-level Dockerfile will be ignored if .binder/Dockerfile exists.

--- a/tests/dockerfile/binder-dir/sayhi.sh
+++ b/tests/dockerfile/binder-dir/sayhi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo hi
+exit 0

--- a/tests/dockerfile/binder-dir/verify
+++ b/tests/dockerfile/binder-dir/verify
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+/usr/local/bin/sayhi.sh

--- a/tests/venv/binder-dir/.binder/postBuild
+++ b/tests/venv/binder-dir/.binder/postBuild
@@ -1,0 +1,2 @@
+#!/bin/bash
+jupyter nbextension enable --py --sys-prefix ipyleaflet

--- a/tests/venv/binder-dir/.binder/requirements.txt
+++ b/tests/venv/binder-dir/.binder/requirements.txt
@@ -1,0 +1,1 @@
+ipyleaflet

--- a/tests/venv/binder-dir/README.rst
+++ b/tests/venv/binder-dir/README.rst
@@ -1,0 +1,4 @@
+Binder Directory
+----------------
+
+top-level environment.yml will be ignored if .binder/requiremets.txt exists.

--- a/tests/venv/binder-dir/environment.yml
+++ b/tests/venv/binder-dir/environment.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - thiswontwork
+  invalid

--- a/tests/venv/binder-dir/verify
+++ b/tests/venv/binder-dir/verify
@@ -1,0 +1,4 @@
+#!/bin/bash
+test -z $(pip list | grep scipy)
+jupyter nbextension list
+jupyter nbextension list | grep 'jupyter-leaflet' | grep enabled


### PR DESCRIPTION
If .binder exists, top-level files are ignored. This allows for top-level Dockerfiles for other uses, but binder-specific environment.yml, etc.

closes #72, #73