### PR TITLE
Switch base image to alpine + fix typo causing CI to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-FROM ubuntu:17.04
+FROM python:3.6.3-alpine3.6
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
-            python3 \
-            python3-pip \
-            python3-setuptools \
-            git && \
-    apt-get clean && apt-get purge
 
 RUN mkdir /tmp/src
 ADD . /tmp/src

--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -6,6 +6,6 @@ VERSION=$(git rev-parse --short HEAD)
 docker build -t jupyter/repo2docker:${VERSION} .
 
 if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
+    docker login -u ${DOCKER_LOGIN} -p "${DOCKER_PASSWORD}"
     docker push jupyter/rep2docker:${VERSION}
 fi


### PR DESCRIPTION
    This cuts image size from under 300MB to under 100MB. Plus
    we will never actually need this to have additional libraries
    installed, since it's talking to the docker socket directly
    to build new images. So switching to alpine here is worth it.

