### PR TITLE
Add git to the repo2docker docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6.3-alpine3.6
 
+# Git is required for repo2docker to work
+RUN apk add --no-cache git
 
 RUN mkdir /tmp/src
 ADD . /tmp/src


### PR DESCRIPTION
Without this, repo2docker just fails.

Caused https://github.com/jupyterhub/mybinder.org-deploy/pull/52 to fail.