### PR TITLE
Remove intermediate containers in failed builds

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -420,6 +420,8 @@ class BuildPack(LoggingConfigurable):
                     'JUPYTERHUB_VERSION': self.jupyterhub_version,
                 },
                 decode=True,
+                forcerm=True,
+                rm=True
         ):
             yield line
 


### PR DESCRIPTION
Fixes  https://github.com/jupyterhub/binderhub/issues/200