### PR TITLE
Only parse `REQUIRE` file in `binder` (if exists)

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -701,14 +701,14 @@ class JuliaBuildPack(BuildPack):
             # Pre-compile all libraries if they've opted into it. `using {libraryname}` does the
             # right thing
             r"""
-            cat "%s" >> ${JULIA_PKGDIR}/v0.6/REQUIRE && \
+            cat "%(require)s" >> ${JULIA_PKGDIR}/v0.6/REQUIRE && \
             julia -e ' \
                Pkg.resolve(); \
-               for pkg in keys(Pkg.Reqs.parse("%s")) \
+               for pkg in keys(Pkg.Reqs.parse("%(require)s")) \
                 eval(:(using $(Symbol(pkg)))) \
                end \
             '
-            """ % require
+            """ % { "require" : require }
         )]
 
     def detect(self):

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -704,7 +704,7 @@ class JuliaBuildPack(BuildPack):
             cat "%s" >> ${JULIA_PKGDIR}/v0.6/REQUIRE && \
             julia -e ' \
                Pkg.resolve(); \
-               for pkg in keys(Pkg.Reqs.parse("REQUIRE")) \
+               for pkg in keys(Pkg.Reqs.parse("%s")) \
                 eval(:(using $(Symbol(pkg)))) \
                end \
             '


### PR DESCRIPTION
If the `binder` folder is in a package directory, then the existing setup will call `using` on the package requirements instead of `binder/REQUIRE`.  This can run into some issues if the package requires a specific version of Julia:

```
ERROR: ArgumentError: Module julia not found in current path.
Run `Pkg.add("julia")` to install the julia package.
```