### PR TITLE
reorganizing arguments

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -152,7 +152,7 @@ class Repo2Docker(Application):
 
         argparser.add_argument(
             'cmd',
-            action='append',
+            nargs=argparse.REMAINDER,
             help='Custom command to run after building container'
         )
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -152,7 +152,7 @@ class Repo2Docker(Application):
 
         argparser.add_argument(
             'cmd',
-            nargs='*',
+            action='append',
             help='Custom command to run after building container'
         )
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -138,16 +138,22 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
-            '--push',
-            dest='push',
-            action='store_true',
-            help='Push docker image to repository'
-        )
-
-        argparser.add_argument(
             '--debug',
             help="Turn on debug logging",
             action='store_true',
+        )
+
+        argparser.add_argument(
+            '--no-build',
+            dest='build',
+            action='store_false',
+            help="Do not actually build the image. Useful in conjunction with --debug."
+        )
+
+        argparser.add_argument(
+            'cmd',
+            nargs='*',
+            help='Custom command to run after building container'
         )
 
         argparser.add_argument(
@@ -165,16 +171,10 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
-            '--no-build',
-            dest='build',
-            action='store_false',
-            help="Do not actually build the image. Useful in conjunction with --debug."
-        )
-
-        argparser.add_argument(
-            'cmd',
-            nargs='*',
-            help='Custom command to run after building container'
+            '--push',
+            dest='push',
+            action='store_true',
+            help='Push docker image to repository'
         )
 
         return argparser


### PR DESCRIPTION
This reorganizes a couple of the docstring parameters so that they more naturally follow linear time. LMK if you think there is a more intuitive ordering here. I saw that @ctb was running `--no-run` assuming it was `--no-build`, so hopefully this will catch some of those usage patterns.

This assumes the order of operations is:

build -> cmd -> run -> push