### PR TITLE
updating index and api page

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,10 @@
+repo2docker API
+---------------
+
+The following arguments may be given in the call to::
+
+  jupyter-repo2docker <path-or-url-to-git-repo>
+
+.. autotraitletsdocumentation::
+
+   XXX how to do this?

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,9 @@ The following arguments may be given in the call to::
 
   jupyter-repo2docker <path-or-url-to-git-repo>
 
-.. autotraitletsdocumentation::
 
-   XXX how to do this?
+repo2docker arguments
+=====================
+
+.. autoconfigurable:: repo2docker.app.Repo2Docker
+    :members: get_argparser

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,15 @@
 # For conversion from markdown to html
 import recommonmark.parser
 
+# Get correct paths
+import sys
+import os
+from os.path import dirname
+docs = dirname(dirname(__file__))
+root = dirname(docs)
+sys.path.insert(0, root)
+sys.path.insert(0, os.path.join(docs, 'sphinxext'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -35,6 +44,8 @@ import recommonmark.parser
 # ones.
 extensions = [
     'jupyter_alabaster_theme',
+    'sphinx.ext.autodoc',
+    'autodoc_traits'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Call repo2docker with following command::
 
   jupyter-repo2docker <path-or-url-to-git-repo>
 
-See the :ref:`api` for more detail on invoking this command.
+See the :doc:`api` for more detail on invoking this command.
 
 Site Contents
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,32 @@
 jupyter-repo2docker
 ===================
 
-**jupyter-repo2docker** is a tool to build, run, and push Docker
-images from source code repositories. See the list below for various
-ways in which you can use ``repo2docker``.
+**jupyter-repo2docker** is a tool to deterministically build, run, and
+push Docker images from source code repositories. It supports a number of
+build file types that install various aspects of a computational environment.
+For a list of supported build file types, see the list below, as well as
+the :ref:`sample_build_files`.
+
+Installation
+------------
+
+You can install ``repo2docker`` with ``pip``::
+
+  pip install jupyter-repo2docker
+
+Usage
+-----
+
+Call repo2docker with following command::
+
+  jupyter-repo2docker <path-or-url-to-git-repo>
+
+See the :ref:`api` for more detail on invoking this command.
 
 Site Contents
 -------------
 .. toctree::
    :maxdepth: 2
 
+   api
    samples

--- a/docs/source/samples.rst
+++ b/docs/source/samples.rst
@@ -1,3 +1,5 @@
+.. _sample_build_files:
+
 Sample build files
 ==================
 

--- a/docs/sphinxext/autodoc_traits.py
+++ b/docs/sphinxext/autodoc_traits.py
@@ -1,0 +1,54 @@
+"""autodoc extension for configurable traits"""
+
+from traitlets import TraitType, Undefined
+from sphinx.domains.python import PyClassmember
+from sphinx.ext.autodoc import ClassDocumenter, AttributeDocumenter
+
+
+class ConfigurableDocumenter(ClassDocumenter):
+    """Specialized Documenter subclass for traits with config=True"""
+    objtype = 'configurable'
+    directivetype = 'class'
+
+    def get_object_members(self, want_all):
+        """Add traits with .tag(config=True) to members list"""
+        check, members = super().get_object_members(want_all)
+        get_traits = self.object.class_own_traits if self.options.inherited_members \
+                     else self.object.class_traits
+        trait_members = []
+        for name, trait in sorted(get_traits(config=True).items()):
+            # put help in __doc__ where autodoc will look for it
+            trait.__doc__ = trait.help
+            trait_members.append((name, trait))
+        return check, trait_members + members
+
+
+class TraitDocumenter(AttributeDocumenter):
+    objtype = 'trait'
+    directivetype = 'attribute'
+    member_order = 1
+    priority = 100
+
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        return isinstance(member, TraitType)
+
+    def format_name(self):
+        return 'config c.' + super().format_name()
+
+    def add_directive_header(self, sig):
+        default = self.object.get_default_value()
+        if default is Undefined:
+            default_s = ''
+        else:
+            default_s = repr(default)
+        sig = ' = {}({})'.format(
+            self.object.__class__.__name__,
+            default_s,
+        )
+        return super().add_directive_header(sig)
+
+
+def setup(app):
+    app.add_autodocumenter(ConfigurableDocumenter)
+    app.add_autodocumenter(TraitDocumenter)


### PR DESCRIPTION
This updates the index page, and also adds an API page. I'm not sure how to document a traitlets API automatically...anyone have an idea for how to do this with sphinx? @yuvipanda or @minrk or @willingc ?


(the `samples.rst` is also moved from CRLF to LF, *hides head in shame*)