### PR TITLE
Remove jupyterhub from default installs

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -1,6 +1,7 @@
 """repo2docker: convert git repositories into jupyter-suitable docker images
 
-Images produced by repo2docker can be used with Jupyter notebooks standalone or via JupyterHub.
+Images produced by repo2docker can be used with Jupyter notebooks standalone,
+with BinderHub, or with JupyterHub.
 
 Usage:
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -1,7 +1,7 @@
 """repo2docker: convert git repositories into jupyter-suitable docker images
 
-Images produced by repo2docker can be used with Jupyter notebooks standalone,
-with BinderHub, or with JupyterHub.
+Images produced by repo2docker can be used with Jupyter notebooks standalone
+or with BinderHub.
 
 Usage:
 

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -398,9 +398,7 @@ class BuildPack(LoggingConfigurable):
                 fileobj=tarf,
                 tag=image_spec,
                 custom_context=True,
-                buildargs={
-                    'JUPYTERHUB_VERSION': self.jupyterhub_version,
-                },
+                buildargs={},
                 decode=True,
         ):
             yield line
@@ -714,9 +712,7 @@ class DockerBuildPack(BuildPack):
                 path=os.getcwd(),
                 dockerfile=self.binder_path(self.dockerfile),
                 tag=image_spec,
-                buildargs={
-                    'JUPYTERHUB_VERSION': self.jupyterhub_version,
-                },
+                buildargs={},
                 decode=True,
         ):
             yield line

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -64,9 +64,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 {% endif -%}
 
-# make JUPYTERHUB_VERSION a build argument
-ARG JUPYTERHUB_VERSION=0.7.2
-
 EXPOSE 8888
 
 {% if env -%}
@@ -139,21 +136,6 @@ class BuildPack(LoggingConfigurable):
     and there are *some* general guarantees of ordering.
 
     """
-
-    jupyterhub_version = Unicode(
-        '0.7.2',
-        config=True,
-        help="""JupyterHub version to install.
-
-        In general, the JupyterHub version in the image
-        and the Hub itself should have the same version number.
-        """
-    )
-    @default('jupyterhub_version')
-    def _jupyterhub_version_default(self):
-        """Allow setting JUPYTERHUB_VERSION via env"""
-        return os.environ.get('JUPYTERHUB_VERSION') or '0.7.2'
-
     packages = Set(
         help="""
         List of packages that are installed in this BuildPack by default.
@@ -511,7 +493,6 @@ class PythonBuildPack(BuildPack):
             r"""
             pip install --no-cache-dir \
                 notebook==5.2.0 \
-                jupyterhub==${JUPYTERHUB_VERSION} \
                 ipywidgets==6.0.0 \
                 jupyterlab==0.28 && \
             jupyter nbextension enable --py widgetsnbextension --sys-prefix && \

--- a/repo2docker/files/conda/install-miniconda.bash
+++ b/repo2docker/files/conda/install-miniconda.bash
@@ -30,7 +30,7 @@ ${CONDA_DIR}/bin/conda config --system --set update_dependencies false
 ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true
 
 ${CONDA_DIR}/bin/conda env update -n root -f /tmp/environment.yml
-${CONDA_DIR}/bin/pip install --no-cache-dir jupyterhub==${JUPYTERHUB_VERSION}
+
 # Clean things out!
 ${CONDA_DIR}/bin/conda clean -tipsy
 

--- a/tests/dockerfile/binder-dir/binder/Dockerfile
+++ b/tests/dockerfile/binder-dir/binder/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.5
 
-ARG JUPYTERHUB_VERSION
-RUN pip3 install jupyterhub==$JUPYTERHUB_VERSION
-
 ENTRYPOINT "/bin/sh"
 
 ADD sayhi.sh /usr/local/bin/sayhi.sh

--- a/tests/dockerfile/jupyter-stack/Dockerfile
+++ b/tests/dockerfile/jupyter-stack/Dockerfile
@@ -1,7 +1,4 @@
 FROM jupyter/base-notebook:b4dd11e16ae4
 
-ARG JUPYTERHUB_VERSION
-RUN pip install jupyterhub==$JUPYTERHUB_VERSION
-
 RUN pip install there
 ADD verify verify

--- a/tests/dockerfile/simple/Dockerfile
+++ b/tests/dockerfile/simple/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.5
 
-ARG JUPYTERHUB_VERSION
-RUN pip3 install jupyterhub==$JUPYTERHUB_VERSION
-
 ENTRYPOINT "/bin/sh"
 
 ADD sayhi.sh /usr/local/bin/sayhi.sh


### PR DESCRIPTION
Closes #92 

Remove jupyterhub from dockerfiles, build args, and tests.

Left jupyterhub code in legacy dockerfiles and tests.