### PR TITLE
[MRG] Remove intermediate docker containers

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -420,6 +420,7 @@ class BuildPack(LoggingConfigurable):
                     'JUPYTERHUB_VERSION': self.jupyterhub_version,
                 },
                 decode=True,
+                rm=True,
         ):
             yield line
 
@@ -737,6 +738,7 @@ class DockerBuildPack(BuildPack):
                     'JUPYTERHUB_VERSION': self.jupyterhub_version,
                 },
                 decode=True,
+                rm=True,
         ):
             yield line
 


### PR DESCRIPTION
Remove intermediate containers for successful builds. As far as I can tell this does not influence the caching behaviour but makes `docker ps -a` much nicer to look at.