### PR TITLE
[MRG] Add limit on git clone depth

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -104,7 +104,7 @@ class Repo2Docker(Application):
             except subprocess.CalledProcessError:
                 self.log.error('Failed to clone repository!',
                                extra=dict(phase='failed'))
-                sys.exit(1)
+                raise RuntimeError("Failed to clone %s." % url)
 
         def _unshallow():
             try:
@@ -115,7 +115,8 @@ class Repo2Docker(Application):
             except subprocess.CalledProcessError:
                 self.log.error('Failed to unshallow repository!',
                                extra=dict(phase='failed'))
-                sys.exit(1)
+                raise RuntimeError("Failed to create a full clone of"
+                                   " %s." % url)
 
         def _contains(ref):
             try:
@@ -137,15 +138,16 @@ class Repo2Docker(Application):
             except subprocess.CalledProcessError:
                 self.log.error('Failed to check out ref %s', ref,
                                extra=dict(phase='failed'))
-                sys.exit(1)
+                raise RuntimeError("Failed to checkout reference %s for"
+                                   " %s." % (ref, url))
 
         # create a shallow clone first
         _clone(depth=50)
-        if ref:
-            if not _contains(ref):
-                # have to create a full clone
-                _unshallow()
-            _checkout(ref)
+
+        if not _contains(ref):
+            # have to create a full clone
+            _unshallow()
+        _checkout(ref)
 
     def get_argparser(self):
         argparser = argparse.ArgumentParser()

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -92,7 +92,8 @@ class Repo2Docker(Application):
 
     def fetch(self, url, ref, checkout_path):
         try:
-            for line in execute_cmd(['git', 'clone', url, checkout_path],
+            for line in execute_cmd(['git', 'clone', '--depth', '50',
+                                     url, checkout_path],
                                     capture=self.json_logs):
                 self.log.info(line, extra=dict(phase='fetching'))
         except subprocess.CalledProcessError:

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -91,23 +91,61 @@ class Repo2Docker(Application):
     )
 
     def fetch(self, url, ref, checkout_path):
-        try:
-            for line in execute_cmd(['git', 'clone', '--depth', '50',
-                                     url, checkout_path],
-                                    capture=self.json_logs):
-                self.log.info(line, extra=dict(phase='fetching'))
-        except subprocess.CalledProcessError:
-            self.log.error('Failed to clone repository!', extra=dict(phase='failed'))
-            sys.exit(1)
+        def _clone(depth=None):
+            if depth is not None:
+                command = ['git', 'clone', '--depth', str(depth),
+                           url, checkout_path]
+            else:
+                command = ['git', 'clone', url, checkout_path]
 
-        if ref:
             try:
-                for line in execute_cmd(['git', 'reset', '--hard', ref], cwd=checkout_path,
+                for line in execute_cmd(command, capture=self.json_logs):
+                    self.log.info(line, extra=dict(phase='fetching'))
+            except subprocess.CalledProcessError:
+                self.log.error('Failed to clone repository!',
+                               extra=dict(phase='failed'))
+                sys.exit(1)
+
+        def _unshallow():
+            try:
+                for line in execute_cmd(['git', 'fetch', '--unshallow'],
+                                        capture=self.json_logs,
+                                        cwd=checkout_path):
+                    self.log.info(line, extra=dict(phase='fetching'))
+            except subprocess.CalledProcessError:
+                self.log.error('Failed to unshallow repository!',
+                               extra=dict(phase='failed'))
+                sys.exit(1)
+
+        def _contains(ref):
+            try:
+                for line in execute_cmd(['git', 'cat-file', '-t', ref],
+                                        capture=self.json_logs,
+                                        cwd=checkout_path):
+                    self.log.debug(line, extra=dict(phase='fetching'))
+            except subprocess.CalledProcessError:
+                return False
+
+            return True
+
+        def _checkout(ref):
+            try:
+                for line in execute_cmd(['git', 'reset', '--hard', ref],
+                                        cwd=checkout_path,
                                         capture=self.json_logs):
                     self.log.info(line, extra=dict(phase='fetching'))
             except subprocess.CalledProcessError:
-                self.log.error('Failed to check out ref %s', ref, extra=dict(phase='failed'))
+                self.log.error('Failed to check out ref %s', ref,
+                               extra=dict(phase='failed'))
                 sys.exit(1)
+
+        # create a shallow clone first
+        _clone(depth=50)
+        if ref:
+            if not _contains(ref):
+                # have to create a full clone
+                _unshallow()
+            _checkout(ref)
 
     def get_argparser(self):
         argparser = argparse.ArgumentParser()

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -731,9 +731,7 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
     USER main
     WORKDIR /home/main/notebooks
     ENV PATH /home/main/anaconda2/envs/python3/bin:$PATH
-    ARG JUPYTERHUB_VERSION
     RUN conda install -yq -n python3 notebook==5.0.0 ipykernel==4.6.0 && \
-        pip install --no-cache-dir jupyterhub==${JUPYTERHUB_VERSION} && \
         conda remove -yq -n python3 nb_conda_kernels && \
         conda install -yq -n root ipykernel==4.6.0 && \
         /home/main/anaconda2/envs/python3/bin/ipython kernel install --sys-prefix && \

--- a/tests/dockerfile/legacy/verify
+++ b/tests/dockerfile/legacy/verify
@@ -5,4 +5,3 @@ import sys
 assert sys.version_info[:2] == (3, 5), sys.version
 
 import jupyter
-import jupyterhub

--- a/tests/external/datasci-shallow-clone.repos.yaml
+++ b/tests/external/datasci-shallow-clone.repos.yaml
@@ -1,0 +1,6 @@
+# Check that we correctly detect that this ref is more than 50 commits ago
+# and trigger a full clone of the repository
+- name: Jake's Data Science Book
+  url: https://github.com/jakevdp/PythonDataScienceHandbook
+  ref: 8761de29a853f0c187286b7c7bc1e4767e7c5574
+  verify: python -c 'import matplotlib'

--- a/tests/external/datasci-shallow-clone.repos.yaml
+++ b/tests/external/datasci-shallow-clone.repos.yaml
@@ -1,6 +1,6 @@
 # Check that we correctly detect that this ref is more than 50 commits ago
 # and trigger a full clone of the repository
 - name: Jake's Data Science Book
-  url: https://github.com/jakevdp/PythonDataScienceHandbook
-  ref: 8761de29a853f0c187286b7c7bc1e4767e7c5574
-  verify: python -c 'import matplotlib'
+  url: https://github.com/betatim/repo2docker-ci-clone-depth
+  ref: f702ae5c612ca0dcaf77954f9f5dd4ede7cb9b5f
+  verify: python -c "commit = open('COMMIT').read(); assert int(commit) == 1, 'this is not the first commit'"

--- a/tests/external/datasci-shallow-clone.repos.yaml
+++ b/tests/external/datasci-shallow-clone.repos.yaml
@@ -1,6 +1,0 @@
-# Check that we correctly detect that this ref is more than 50 commits ago
-# and trigger a full clone of the repository
-- name: Jake's Data Science Book
-  url: https://github.com/betatim/repo2docker-ci-clone-depth
-  ref: f702ae5c612ca0dcaf77954f9f5dd4ede7cb9b5f
-  verify: python -c "commit = open('COMMIT').read(); assert int(commit) == 1, 'this is not the first commit'"

--- a/tests/external/shallow-clone.repos.yaml
+++ b/tests/external/shallow-clone.repos.yaml
@@ -1,0 +1,13 @@
+# Check that we correctly detect that this ref is more than 50 commits ago
+# and trigger a full clone of the repository
+- name: A dummy repo with 100 commits - unshallow to reach ref
+  url: https://github.com/betatim/repo2docker-ci-clone-depth
+  ref: f702ae5c612ca0dcaf77954f9f5dd4ede7cb9b5f
+  verify: python -c "commit = open('COMMIT').read(); assert int(commit) == 1, 'this is not the first commit'"
+
+- name: A dummy repo with 100 commits - shallow clone is enough
+  url: https://github.com/betatim/repo2docker-ci-clone-depth
+  ref: 28674ab4da34585525d9c5451f6d6a872522d017
+  # we checkout the second to last commit, hence the log has 49 entries at a
+  # max clone depth of 50
+  verify: /bin/bash -c '[ $(git log --oneline | wc -l) == "49" ]'


### PR DESCRIPTION
Only checkout last 50 commits from a remote repository. This helps speed
up the cloning for large repositories.

50 is the same depth to which travis clones by default. This does have the potential to fail though because there is no reason for the ref we might want to checkout to be in the last 50 commits.

WDYT?