### PR TITLE
Add 'repo2docker' as a script alias

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     entry_points={
         'console_scripts': [
             'jupyter-repo2docker = repo2docker.__main__:main',
+            'repo2docker = repo2docker.__main__:main',
         ]
     },
 )


### PR DESCRIPTION
jupyter-repo2docker is a mouthful