### PR TITLE
Add handling for no ref being provided

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -144,10 +144,13 @@ class Repo2Docker(Application):
         # create a shallow clone first
         _clone(depth=50)
 
-        if not _contains(ref):
-            # have to create a full clone
-            _unshallow()
-        _checkout(ref)
+        # ref == None means we want to use HEAD so no need to checkout a
+        # specific revision
+        if ref is not None:
+            if not _contains(ref):
+                # have to create a full clone
+                _unshallow()
+            _checkout(ref)
 
     def get_argparser(self):
         argparser = argparse.ArgumentParser()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,8 @@ class RemoteRepoTest(pytest.Item):
         self.verify = verify
 
     def runtest(self):
-        subprocess.check_call([
-            'jupyter-repo2docker',
-            '--ref', self.ref,
-            self.url,
-            '--',
-        ] + shlex.split(self.verify))
+        if self.ref is not None:
+            cmd = ['jupyter-repo2docker', '--ref', self.ref, self.url, '--']
+        else:
+            cmd = ['jupyter-repo2docker', self.url, '--']
+        subprocess.check_call(cmd + shlex.split(self.verify))

--- a/tests/external/shallow-clone.repos.yaml
+++ b/tests/external/shallow-clone.repos.yaml
@@ -11,3 +11,9 @@
   # we checkout the second to last commit, hence the log has 49 entries at a
   # max clone depth of 50
   verify: /bin/bash -c '[ $(git log --oneline | wc -l) == "49" ]'
+
+- name: A dummy repo with 100 commits - live at HEAD
+  url: https://github.com/betatim/repo2docker-ci-clone-depth
+  # provide no ref, aka use HEAD, aka the 100th commit
+  ref: NULL
+  verify: python -c "commit = open('COMMIT').read(); assert int(commit) == 100, 'this is not the 100th commit'"


### PR DESCRIPTION
Fixes the bug noticed (and reverted) here: jupyterhub/mybinder.org-deploy#112

We do not need to checkout a specific ref if none is provided. Added a test to check the behaviour.

The big question is: when does binderhub call `repo2docker` without a ref as commandline argument?