### PR TITLE
Fully remove jupyterhub references

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -733,9 +733,7 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
     USER main
     WORKDIR /home/main/notebooks
     ENV PATH /home/main/anaconda2/envs/python3/bin:$PATH
-    ARG JUPYTERHUB_VERSION
     RUN conda install -yq -n python3 notebook==5.0.0 ipykernel==4.6.0 && \
-        pip install --no-cache-dir jupyterhub==${JUPYTERHUB_VERSION} && \
         conda remove -yq -n python3 nb_conda_kernels && \
         conda install -yq -n root ipykernel==4.6.0 && \
         /home/main/anaconda2/envs/python3/bin/ipython kernel install --sys-prefix && \

--- a/tests/dockerfile/legacy/verify
+++ b/tests/dockerfile/legacy/verify
@@ -5,4 +5,3 @@ import sys
 assert sys.version_info[:2] == (3, 5), sys.version
 
 import jupyter
-import jupyterhub


### PR DESCRIPTION
Rescued the JupyterHub related commits out of the reverts in #130 & #131 

