### PR TITLE
[WIP] Use `repository/` subdirectory to store contents

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -126,6 +126,12 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
+            '--mount',
+            default='/',
+            help='Mount local repository into container instead of copying it'
+        )
+
+        argparser.add_argument(
             'repo',
             help='Path to repository that should be built. Could be local path or a git URL.'
         )

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -700,7 +700,7 @@ class JuliaBuildPack(BuildPack):
                 eval(:(using $(Symbol(pkg)))) \
                end \
             '
-            """ % { "require" : require }
+            """ % { "require" : self.repo_path(require) }
         )]
 
     def detect(self):

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -319,6 +319,14 @@ class BuildPack(LoggingConfigurable):
         else:
             return path
 
+    def repo_path(self, path):
+        """Locate file inside repository after copying it to the container"""
+        if path.startswith('binder/'):
+            return os.path.join('repository', path)
+        else:
+            path = self.binder_path(path)
+            return os.path.join('repository', path)
+
     def detect(self):
         return all([p.detect() for p in self.components])
 
@@ -451,7 +459,7 @@ class BaseImage(BuildPack):
             if not stat.S_IXUSR & os.stat(post_build).st_mode:
                 raise ValueError("%s is not executable, see %s for help." % (
                                  post_build, DOC_URL+'#system-post-build-scripts'))
-            return [post_build]
+            return [self.repo_path(post_build)]
         return []
 
 class PythonBuildPack(BuildPack):
@@ -522,7 +530,8 @@ class PythonBuildPack(BuildPack):
         if os.path.exists(requirements_file):
             return [(
                 '${NB_USER}',
-                'pip3 install --no-cache-dir -r "{}"'.format(requirements_file)
+                'pip3 install --no-cache-dir -r "{}"'.format(
+                    self.repo_path(requirements_file))
             )]
         return []
 
@@ -564,7 +573,7 @@ class CondaBuildPack(BuildPack):
                 r"""
                 conda env update -n root -f "{}" && \
                 conda clean -tipsy
-                """.format(os.path.join('repository', environment_yml))
+                """.format(self.repo_path('environment.yml'))
             ))
         return assembly_scripts
 

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -629,7 +629,8 @@ class Python2BuildPack(BuildPack):
         return [
             (
                 '${NB_USER}',
-                'pip2 install --no-cache-dir -r requirements.txt'
+                'pip2 install --no-cache-dir -r {}'.format(
+                    self.repo_path('requirements.txt'))
             )
         ]
 

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -92,7 +92,7 @@ COPY {{ src }} {{ dst }}
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!
 USER root
-COPY src/ ${HOME}
+COPY src/ ${HOME}/repository/
 RUN chown -R ${NB_USER}:${NB_USER} ${HOME}
 
 # Run assemble scripts! These will actually build the specification
@@ -314,10 +314,11 @@ class BuildPack(LoggingConfigurable):
 
     def binder_path(self, path):
         """Locate a file"""
-        if os.path.exists('binder'):
-            return os.path.join('binder', path)
+        binder_dir = os.path.join('repository', 'binder')
+        if os.path.exists(binder_dir):
+            return os.path.join(binder_dir, path)
         else:
-            return path
+            return os.path.join('repository', path)
 
     def detect(self):
         return all([p.detect() for p in self.components])

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -92,7 +92,7 @@ COPY {{ src }} {{ dst }}
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!
 USER root
-COPY src/ ${HOME}/repository/
+COPY src/ ${HOME}
 RUN chown -R ${NB_USER}:${NB_USER} ${HOME}
 
 # Run assemble scripts! These will actually build the specification
@@ -277,6 +277,15 @@ class BuildPack(LoggingConfigurable):
         """
     )
 
+    repository_path = Unicode(
+        "",
+        help="""
+        Sub-directory at which to mount repository.
+
+        Defaults to the home directory.
+        """
+    )
+
     components = Tuple(())
 
     def compose_with(self, other):
@@ -322,10 +331,10 @@ class BuildPack(LoggingConfigurable):
     def repo_path(self, path):
         """Locate file inside repository after copying it to the container"""
         if path.startswith('binder/'):
-            return os.path.join('repository', path)
+            return os.path.join(self.repository_path, path)
         else:
             path = self.binder_path(path)
-            return os.path.join('repository', path)
+            return os.path.join(self.repository_path, path)
 
     def detect(self):
         return all([p.detect() for p in self.components])

--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -314,11 +314,10 @@ class BuildPack(LoggingConfigurable):
 
     def binder_path(self, path):
         """Locate a file"""
-        binder_dir = os.path.join('repository', 'binder')
-        if os.path.exists(binder_dir):
-            return os.path.join(binder_dir, path)
+        if os.path.exists('binder'):
+            return os.path.join('binder', path)
         else:
-            return os.path.join('repository', path)
+            return path
 
     def detect(self):
         return all([p.detect() for p in self.components])
@@ -422,7 +421,7 @@ class BaseImage(BuildPack):
     def setup_assembly(self):
         assemble_scripts = []
         try:
-            with open('apt.txt') as f:
+            with open(self.binder_path('apt.txt')) as f:
                 extra_apt_packages = [l.strip() for l in f]
             # Validate that this is, indeed, just a list of packages
             # We're doing shell injection around here, gotta be careful.
@@ -565,12 +564,13 @@ class CondaBuildPack(BuildPack):
                 r"""
                 conda env update -n root -f "{}" && \
                 conda clean -tipsy
-                """.format(environment_yml)
+                """.format(os.path.join('repository', environment_yml))
             ))
         return assembly_scripts
 
     def detect(self):
-        return os.path.exists(self.binder_path('environment.yml')) and super().detect()
+        return (os.path.exists(self.binder_path('environment.yml')) and
+                super().detect())
 
 
 class Python2BuildPack(BuildPack):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ class LocalRepoTest(pytest.Item):
         subprocess.check_call([
             'jupyter-repo2docker',
             str(self.path.dirname),
-            './verify'
+            './repository/verify'
         ])
 
 


### PR DESCRIPTION
Fixes #129 

Using a subdirectory allows us to mount the contents of the repository
from a volume instead of copying it.