### PR TITLE
RFC: Ignore "julia" in REQUIRE file when precompiling

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -686,7 +686,7 @@ class JuliaBuildPack(BuildPack):
             julia -e ' \
                Pkg.resolve(); \
                for pkg in keys(Pkg.Reqs.parse("%(require)s")) \
-                eval(:(using $(Symbol(pkg)))) \
+                pkg != "julia" && eval(:(using $(Symbol(pkg)))) \
                end \
             '
             """ % { "require" : require }


### PR DESCRIPTION
Otherwise builds will throw an error if a specific version of Julia is listed in `REQUIRE`.