### PR TITLE
add git-credential-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN apk add --no-cache git
 
 RUN mkdir /tmp/src
 ADD . /tmp/src
-RUN pip3 install --no-cache-dir /tmp/src && \
-    cp /tmp/src/docker/git-credential-env /usr/local/bin/git-credential-env && \
+RUN pip3 install --no-cache-dir /tmp/src
+RUN cp /tmp/src/docker/git-credential-env /usr/local/bin/git-credential-env && \
     git config --system credential.helper env

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN apk add --no-cache git
 
 RUN mkdir /tmp/src
 ADD . /tmp/src
-RUN pip3 install --no-cache-dir /tmp/src
-
+RUN pip3 install --no-cache-dir /tmp/src && \
+    cp /tmp/src/docker/git-credential-env /usr/local/bin/git-credential-env && \
+    git config --system credential.helper env

--- a/docker/git-credential-env
+++ b/docker/git-credential-env
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo -e $GIT_CREDENTIAL_ENV


### PR DESCRIPTION
and configure git to use it by default

`git-credential-env` only echoes the $GIT_CREDENTIAL_ENV environment variable when git asks for https credentials.

with this, setting GIT_CREDENTIAL_ENV="username=name\npassword=xxx" sets the credentials that will be used in clone for login-requiring endpoints (this is only when a username and password are prompted for, not all clones).

e.g.

    docker run -e GIT_CREDENTIAL_ENV="username=name\npassword=xxx" jupyter/repo2docker https://github.com/private/repo

cc @drorata this is step one toward getting credentials into the build without using the token-including clone URL, which exposes the credentials inside the user containers.

To get private repo support in binderhub, we ought to only need to pass this GIT_CREDENTIAL_ENV to the build pod.