### PR TITLE
Make all bash verify scripts fail on error

### DIFF
--- a/tests/dockerfile/binder-dir/verify
+++ b/tests/dockerfile/binder-dir/verify
@@ -1,3 +1,3 @@
 #!/bin/sh
-set -e
+set -euo pipefail
 /usr/local/bin/sayhi.sh

--- a/tests/dockerfile/simple/verify
+++ b/tests/dockerfile/simple/verify
@@ -1,3 +1,3 @@
 #!/bin/sh
-set -e
+set -euo pipefail
 /usr/local/bin/sayhi.sh

--- a/tests/venv/apt-packages/verify
+++ b/tests/venv/apt-packages/verify
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -euo pipefail
 which gfortran

--- a/tests/venv/binder-dir/verify
+++ b/tests/venv/binder-dir/verify
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 which gfortran
 test -z $(pip list | grep scipy)
 jupyter nbextension list

--- a/tests/venv/postBuild/verify
+++ b/tests/venv/postBuild/verify
@@ -1,3 +1,3 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 jupyter nbextension list | grep 'jupyter-leaflet' | grep enabled


### PR DESCRIPTION
Bash scripts by default continue on executing even if any
command errors. That's not the behavior we want for our scripts,
so let's explicitly get them to fail if:

1. Any command exits with non 0 exit code
2. An undefined variable is referenced