### PR TITLE
Make conda env update be verbose

### DIFF
--- a/repo2docker/detectors.py
+++ b/repo2docker/detectors.py
@@ -562,7 +562,7 @@ class CondaBuildPack(BuildPack):
             assembly_scripts.append((
                 '${NB_USER}',
                 r"""
-                conda env update -n root -f "{}" && \
+                conda env update -v -n root -f "{}" && \
                 conda clean -tipsy
                 """.format(environment_yml)
             ))


### PR DESCRIPTION
If you don't turn on verbose updates, then I'm pretty sure the log will look
 like it's hanging while it runs all the install commands under the hood. 
This adds `-v` in the call to `conda env update` which is triggered when 
`environment.yml` is found.