### PR TITLE
don't run tests in parallel on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
 - 3.4
 install:
 - pip install -e .
-- pip install pytest-xdist pyyaml
+- pip install pyyaml
 
 script:
-  - pytest -s -v -n4 tests/${REPO_TYPE}
+  - pytest -s -v tests/${REPO_TYPE}
 
 jobs:
   include:


### PR DESCRIPTION
parallel tests might have been the cause of spurious travis failures

plus, not running concurrently should result in reusing the cache for the initial stages, which might even end up saving time

wip: waiting to see what this does on Travis