### PR TITLE
update venv freeze and conda versions

### DIFF
--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
   - python==3.6.1
   - notebook==5.2.2
-  - ipython==6.0.0
-  - ipykernel==4.6.0
-  - ipywidgets==6.0.0
-  - jupyterlab==0.28
+  - ipython==6.2.1
+  - ipykernel==4.6.1
+  - ipywidgets==6.0.1
+  - jupyterlab==0.29.2

--- a/repo2docker/buildpacks/python/freeze.bash
+++ b/repo2docker/buildpacks/python/freeze.bash
@@ -17,23 +17,23 @@ cd $(dirname "$($realpath "$0")")
 function freeze-requirements {
     # Freeze a requirements file $2 into a frozen requirements file $3
     # Requires that a completely empty venv of appropriate version exist in $1
-    VENV_PATH="$1"
+    PYTHON_VERSION="$1"
     REQUIREMENTS_FILE="$2"
     FROZEN_FILE="$3"
+    if [[ $(echo ${PYTHON_VERSION} | cut -d. -f 1) == "2" ]]; then
+        VENV=virtualenv
+    else
+        VENV=venv
+    fi
 
-    ./${VENV_PATH}/bin/pip install --no-cache-dir -r ${REQUIREMENTS_FILE}
     echo "# AUTO GENERATED FROM ${REQUIREMENTS_FILE}, DO NOT MANUALLY MODIFY" > ${FROZEN_FILE}
     echo "# Frozen on $(date -u)" >> ${FROZEN_FILE}
-    ./${VENV_PATH}/bin/pip freeze | sort >> ${FROZEN_FILE}
+    docker run --rm -v $PWD:/python -it python:${PYTHON_VERSION} \
+        sh -c "
+            python -m $VENV /venv
+            /venv/bin/pip install -r /python/${REQUIREMENTS_FILE} &&
+            /venv/bin/pip freeze | sort --ignore-case >> /python/${FROZEN_FILE}"
 }
 
-rm -rf py3venv
-python3 -m venv py3venv
-freeze-requirements py3venv requirements.txt requirements.frozen.txt
-rm -rf py3venv
-
-
-rm -rf py2venv
-virtualenv -p python2 py2venv
-freeze-requirements py2venv requirements2.txt requirements2.frozen.txt
-rm -rf py2venv
+freeze-requirements 3.5 requirements.txt requirements.frozen.txt
+freeze-requirements 2.7 requirements2.txt requirements2.frozen.txt

--- a/repo2docker/buildpacks/python/freeze.bash
+++ b/repo2docker/buildpacks/python/freeze.bash
@@ -5,7 +5,14 @@ set -euo pipefail
 # Does the same for requirements2.txt to requirements2.frozen.txt...
 
 # cd to the directory where the freeze script is located
-dirname "$(readlink -f "$0")"
+if [[ ! -z "$(which realpath 2>/dev/null)" ]]; then
+    realpath=realpath
+else
+    realpath="readlink -f"
+fi
+
+cd $(dirname "$($realpath "$0")")
+
 
 function freeze-requirements {
     # Freeze a requirements file $2 into a frozen requirements file $3

--- a/repo2docker/buildpacks/python/requirements.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements.frozen.txt
@@ -1,20 +1,20 @@
 # AUTO GENERATED FROM requirements.txt, DO NOT MANUALLY MODIFY
-# Frozen on Thu Nov 30 11:49:16 UTC 2017
+# Frozen on Thu Nov 30 12:03:22 UTC 2017
 bleach==2.1.1
 decorator==4.1.2
 entrypoints==0.2.3
 html5lib==1.0b10
 ipykernel==4.6.1
-ipython==6.2.1
 ipython-genutils==0.2.0
-ipywidgets==6.0.0
+ipython==6.2.1
+ipywidgets==6.0.1
 jedi==0.11.0
 Jinja2==2.10
 jsonschema==2.6.0
 jupyter-client==5.1.0
 jupyter-core==4.4.0
-jupyterlab==0.29.2
 jupyterlab-launcher==0.5.5
+jupyterlab==0.29.2
 MarkupSafe==1.0
 mistune==0.8.1
 nbconvert==5.3.1
@@ -24,7 +24,6 @@ pandocfilters==1.4.2
 parso==0.1.0
 pexpect==4.3.0
 pickleshare==0.7.4
-pkg-resources==0.0.0
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0

--- a/repo2docker/buildpacks/python/requirements.txt
+++ b/repo2docker/buildpacks/python/requirements.txt
@@ -1,3 +1,3 @@
 notebook==5.2.2
-ipywidgets==6.0.0
+ipywidgets==6.0.1
 jupyterlab==0.29.2

--- a/repo2docker/buildpacks/python/requirements2.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements2.frozen.txt
@@ -1,19 +1,18 @@
 # AUTO GENERATED FROM requirements2.txt, DO NOT MANUALLY MODIFY
-# Frozen on Thu Nov 30 11:49:30 UTC 2017
+# Frozen on Thu Nov 30 12:03:43 UTC 2017
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 certifi==2017.11.5
 decorator==4.1.2
 enum34==1.1.6
 ipykernel==4.6.1
-ipython==5.5.0
 ipython-genutils==0.2.0
+ipython==5.5.0
 jupyter-client==5.1.0
 jupyter-core==4.4.0
 pathlib2==2.3.0
 pexpect==4.3.0
 pickleshare==0.7.4
-pkg-resources==0.0.0
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0


### PR DESCRIPTION
follow-up to #156

- sync conda versions with venv pins
- update ipywidgets to 6.0.1
- fix freeze.bash so it runs on macOS (freeze happens in docker)

Specifically not included yet: freezing conda. I'd like to do that in another PR.