### PR TITLE
Set limits for how much memory docker build can use

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -163,7 +163,7 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
-            '---build-memory-limit',
+            '--build-memory-limit',
             help='Total Memory that can be used by the docker build process'
         )
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -29,8 +29,7 @@ from .buildpacks import (
     PythonBuildPack, DockerBuildPack, LegacyBinderDockerBuildPack,
     CondaBuildPack, JuliaBuildPack, Python2BuildPack, BaseImage
 )
-from .utils import execute_cmd
-from .utils import maybe_cleanup
+from .utils import execute_cmd, ByteSpecification, maybe_cleanup
 from . import __version__
 
 
@@ -92,6 +91,16 @@ class Repo2Docker(Application):
         """
     )
 
+    build_memory_limit = ByteSpecification(
+        0,
+        help="""
+        Total memory that can be used by the docker image building process.
+
+        Set to 0 for no limits.
+        """,
+        config=True
+    )
+
     def fetch(self, url, ref, checkout_path):
         try:
             for line in execute_cmd(['git', 'clone', url, checkout_path],
@@ -151,6 +160,11 @@ class Repo2Docker(Application):
             dest='build',
             action='store_false',
             help="Do not actually build the image. Useful in conjunction with --debug."
+        )
+
+        argparser.add_argument(
+            '---build-memory-limit',
+            help='Total Memory that can be used by the docker build process'
         )
 
         argparser.add_argument(
@@ -250,6 +264,9 @@ class Repo2Docker(Application):
 
         self.run_cmd = args.cmd
 
+        if args.build_memory_limit:
+            self.build_memory_limit = args.build_memory_limit
+
     def push_image(self):
         client = docker.APIClient(version='auto', **kwargs_from_env())
         # Build a progress setup for each layer, and only emit per-layer info every 1.5s
@@ -347,7 +364,7 @@ class Repo2Docker(Application):
             if self.build:
                 self.log.info('Using %s builder\n', bp.name,
                               extra=dict(phase='building'))
-                for l in picked_buildpack.build(self.output_image_spec):
+                for l in picked_buildpack.build(self.output_image_spec, self.build_memory_limit):
                     if 'stream' in l:
                         self.log.info(l['stream'],
                                       extra=dict(phase='building'))

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -392,7 +392,7 @@ class BuildPack(LoggingConfigurable):
         limits = {
             # Always disable memory swap for building, since mostly
             # nothing good can come of that.
-            'memoryswap': -1
+            'memswap': -1
         }
         if memory_limit:
             limits['memory'] = memory_limit

--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -18,7 +18,14 @@ class DockerBuildPack(BuildPack):
         with open(Dockerfile) as f:
             return f.read()
 
-    def build(self, image_spec):
+    def build(self, image_spec, memory_limit):
+        limits = {
+            # Always disable memory swap for building, since mostly
+            # nothing good can come of that.
+            'memoryswap': -1
+        }
+        if memory_limit:
+            limits['memory'] = memory_limit
         client = docker.APIClient(version='auto', **docker.utils.kwargs_from_env())
         for line in client.build(
                 path=os.getcwd(),
@@ -27,6 +34,7 @@ class DockerBuildPack(BuildPack):
                 buildargs={},
                 decode=True,
                 forcerm=True,
-                rm=True
+                rm=True,
+                container_limits=limits
         ):
             yield line

--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -22,7 +22,7 @@ class DockerBuildPack(BuildPack):
         limits = {
             # Always disable memory swap for building, since mostly
             # nothing good can come of that.
-            'memoryswap': -1
+            'memswap': -1
         }
         if memory_limit:
             limits['memory'] = memory_limit

--- a/repo2docker/buildpacks/legacy.py
+++ b/repo2docker/buildpacks/legacy.py
@@ -31,10 +31,10 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
         with open('Dockerfile') as f:
             return f.read() + self.dockerfile_appendix
 
-    def build(self, image_spec):
+    def build(self, image_spec, memory_limit):
         with open(self.dockerfile, 'w') as f:
             f.write(self.render())
-        return super().build(image_spec)
+        return super().build(image_spec, memory_limit)
 
     def detect(self):
         try:

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -3,6 +3,7 @@ from functools import partial
 import shutil
 import subprocess
 
+from traitlets import Integer
 
 def execute_cmd(cmd, capture=False, **kwargs):
     """
@@ -51,3 +52,48 @@ def maybe_cleanup(path, cleanup=False):
     yield
     if cleanup:
         shutil.rmtree(path, ignore_errors=True)
+
+
+class ByteSpecification(Integer):
+    """
+    Allow easily specifying bytes in units of 1024 with suffixes
+
+    Suffixes allowed are:
+      - K -> Kilobyte
+      - M -> Megabyte
+      - G -> Gigabyte
+      - T -> Terabyte
+
+    Stolen from JupyterHub
+    """
+
+    UNIT_SUFFIXES = {
+        'K': 1024,
+        'M': 1024 * 1024,
+        'G': 1024 * 1024 * 1024,
+        'T': 1024 * 1024 * 1024 * 1024,
+    }
+
+    # Default to allowing None as a value
+    allow_none = True
+
+    def validate(self, obj, value):
+        """
+        Validate that the passed in value is a valid memory specification
+
+        It could either be a pure int, when it is taken as a byte value.
+        If it has one of the suffixes, it is converted into the appropriate
+        pure byte value.
+        """
+        if isinstance(value, (int, float)):
+            return int(value)
+
+        try:
+            num = float(value[:-1])
+        except ValueError:
+            raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
+        suffix = value[-1]
+        if suffix not in self.UNIT_SUFFIXES:
+            raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
+        else:
+            return int(float(num) * self.UNIT_SUFFIXES[suffix])

--- a/tests/memlimit.py
+++ b/tests/memlimit.py
@@ -15,7 +15,11 @@ def does_build(builddir, mem_limit, mem_allocate_mb):
     # Cache bust so we actually do a rebuild each time this is run!
     with open(os.path.join(builddir, 'cachebust'), 'w') as cachebust:
         cachebust.write(str(time.time()))
+
     try:
+        # we don't have an easy way to pass env vars or whatever to
+        # postBuild from here, so we write a file into the repo that is
+        # read by the postBuild script!
         with open(mem_allocate_mb_file, 'w') as f:
             f.write(str(mem_allocate_mb))
         try:

--- a/tests/memlimit.py
+++ b/tests/memlimit.py
@@ -1,36 +1,77 @@
+"""
+Test that build time memory limits are actually enforced.
+
+We give the container image at least 128M of RAM (so base things like
+apt and pip can run), and then try to allocate & use 256MB in postBuild.
+This should fail!
+"""
+import os
 import subprocess
+import time
 
-def test_memlimit_nondockerfile():
+def does_build(builddir, mem_limit, mem_allocate_mb):
+    mem_allocate_mb_file = os.path.join(builddir, 'mem_allocate_mb')
+
+    # Cache bust so we actually do a rebuild each time this is run!
+    with open(os.path.join(builddir, 'cachebust'), 'w') as cachebust:
+        cachebust.write(str(time.time()))
+    try:
+        with open(mem_allocate_mb_file, 'w') as f:
+            f.write(str(mem_allocate_mb))
+        try:
+            output = subprocess.check_output(
+                [
+                    'repo2docker',
+                    '--no-run',
+                    '--build-memory-limit', '{}M'.format(mem_limit),
+                    builddir
+                ],
+                stderr=subprocess.STDOUT,
+            ).decode()
+            print(output)
+            return True
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode()
+            print(output)
+            if "The command '/bin/sh -c ./postBuild' returned a non-zero code: 137" in output:
+                return False
+            else:
+                raise
+    finally:
+        os.remove(mem_allocate_mb_file)
+
+
+
+def test_memlimit_nondockerfile_fail():
     """
     Test if memory limited builds are working for non dockerfile builds
     """
-    try:
-        subprocess.check_call([
-            'repo2docker',
-            '--no-run',
-            '--build-memory-limit', '4M',
-            'tests/memlimit/non-dockerfile'
-        ])
-        # If this doesn't throw an exception, then memory limit was
-        # not enforced!
-        assert False
-    except subprocess.CalledProcessError as e:
-        assert True
+    basedir = os.path.dirname(__file__)
+    assert not does_build(
+        os.path.join(basedir, 'memlimit/non-dockerfile'),
+        128,
+        256
+    )
+    assert does_build(
+        os.path.join(basedir, 'memlimit/non-dockerfile'),
+        512,
+        256
+    )
 
 
-def test_memlimit_dockerfile():
+def test_memlimit_dockerfile_fail():
     """
-    Test if memory limited builds are working for non dockerfile builds
+    Test if memory limited builds are working for dockerfile builds
     """
-    try:
-        subprocess.check_call([
-            'repo2docker',
-            '--no-run',
-            '--build-memory-limit', '4M',
-            'tests/memlimit/dockerfile'
-        ])
-        # If this doesn't throw an exception, then memory limit was
-        # not enforced!
-        assert False
-    except subprocess.CalledProcessError as e:
-        assert True
+    basedir = os.path.dirname(__file__)
+    assert not does_build(
+        os.path.join(basedir, 'memlimit/dockerfile'),
+        128,
+        256
+    )
+
+    assert does_build(
+        os.path.join(basedir, 'memlimit/dockerfile'),
+        512,
+        256
+    )

--- a/tests/memlimit.py
+++ b/tests/memlimit.py
@@ -1,0 +1,36 @@
+import subprocess
+
+def test_memlimit_nondockerfile():
+    """
+    Test if memory limited builds are working for non dockerfile builds
+    """
+    try:
+        subprocess.check_call([
+            'repo2docker',
+            '--no-run',
+            '--build-memory-limit', '4M',
+            'tests/memlimit/non-dockerfile'
+        ])
+        # If this doesn't throw an exception, then memory limit was
+        # not enforced!
+        assert False
+    except subprocess.CalledProcessError as e:
+        assert True
+
+
+def test_memlimit_dockerfile():
+    """
+    Test if memory limited builds are working for non dockerfile builds
+    """
+    try:
+        subprocess.check_call([
+            'repo2docker',
+            '--no-run',
+            '--build-memory-limit', '4M',
+            'tests/memlimit/dockerfile'
+        ])
+        # If this doesn't throw an exception, then memory limit was
+        # not enforced!
+        assert False
+    except subprocess.CalledProcessError as e:
+        assert True

--- a/tests/memlimit/.gitignore
+++ b/tests/memlimit/.gitignore
@@ -1,0 +1,1 @@
+cachebust

--- a/tests/memlimit/dockerfile/Dockerfile
+++ b/tests/memlimit/dockerfile/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.6
+FROM ubuntu:zesty
 
-COPY postBuild /usr/local/bin/postBuild
+RUN apt-get update && apt-get install --yes python3
+
+COPY . .
 RUN ./postBuild

--- a/tests/memlimit/dockerfile/Dockerfile
+++ b/tests/memlimit/dockerfile/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.6
+
+COPY postBuild /usr/local/bin/postBuild
+RUN ./postBuild

--- a/tests/memlimit/dockerfile/postBuild
+++ b/tests/memlimit/dockerfile/postBuild
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
+"""
+Simplest program that tries to allocate a large amount of RAM.
 
-array = []
-for i in range(1024 * 1024 * 64):
-    array.append(i)
+malloc lies on Linux by default, so we use memset to force the
+kernel to actually give us real memory.
+"""
+from ctypes import cdll, c_void_p, memset
+import os
+
+libc = cdll.LoadLibrary("libc.so.6")
+libc.malloc.restype = c_void_p
+
+with open('mem_allocate_mb') as f:
+    mem_allocate_mb = int(f.read().strip())
+
+size = 1024 * 1024 * mem_allocate_mb
+print("trying to allocate {}MB".format(mem_allocate_mb))
+
+ret = libc.malloc(size)
+
+memset(ret, 0, size)

--- a/tests/memlimit/dockerfile/postBuild
+++ b/tests/memlimit/dockerfile/postBuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+array = []
+for i in range(1024 * 1024 * 64):
+    array.append(i)

--- a/tests/memlimit/non-dockerfile/postBuild
+++ b/tests/memlimit/non-dockerfile/postBuild
@@ -1,5 +1,1 @@
-#!/usr/bin/env python3
-
-array = []
-for i in range(1024 * 1024 * 64):
-    array.append(i)
+../dockerfile/postBuild

--- a/tests/memlimit/non-dockerfile/postBuild
+++ b/tests/memlimit/non-dockerfile/postBuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+array = []
+for i in range(1024 * 1024 * 64):
+    array.append(i)


### PR DESCRIPTION
This prevents builds from gobbling all the RAM on a node!