### PR TITLE
add ability for port mapping to work with non jupyter-workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6.3
 
+# Used for testing purpose in ports.py
+EXPOSE 52000
 RUN mkdir /tmp/src
 ADD . /tmp/src
 RUN pip3 install --no-cache-dir /tmp/src

--- a/tests/argumentvalidation.py
+++ b/tests/argumentvalidation.py
@@ -5,6 +5,7 @@ Tests that runs validity checks on arguments passed in from shell
 import os
 import subprocess
 
+
 def validate_arguments(builddir, args_list, expected):
     try:
         cmd = ['repo2docker']
@@ -101,6 +102,7 @@ def test_image_name_valid_name_success():
 
     assert validate_arguments(builddir, args_list, None)
 
+
 def test_volume_no_build_fail():
     """
     Test to check if repo2docker fails when both --no-build and -v arguments are given
@@ -120,6 +122,7 @@ def test_volume_no_run_fail():
 
     assert not validate_arguments(builddir, args_list, 'To Mount volumes with -v, you also need to run the container')
 
+
 def test_env_no_run_fail():
     """
     Test to check if repo2docker fails when both --no-run and -e arguments are given 
@@ -129,3 +132,58 @@ def test_env_no_run_fail():
 
     assert not validate_arguments(builddir, args_list, 'To specify environment variables, you also need to run the container')
 
+
+def test_port_mapping_no_run_fail():
+    """
+    Test to check if repo2docker fails when both --no-run and --publish arguments are specified.
+    """
+    builddir = os.path.dirname(__file__)
+    args_list = ['--no-run', '--publish', '8000:8000']
+
+    assert not validate_arguments(builddir, args_list, 'To publish user defined port mappings, the container must also be run')
+
+
+def test_all_ports_mapping_no_run_fail():
+    """
+    Test to check if repo2docker fails when both --no-run and -P arguments are specified.
+    """
+    builddir = os.path.dirname(__file__)
+    args_list = ['--no-run', '-P']
+
+    assert not validate_arguments(builddir, args_list, 'To publish user defined port mappings, the container must also be run')
+
+
+def test_invalid_port_mapping_fail():
+    """
+    Test to check if r2d fails when an invalid port is specified in the port mapping
+    """
+    builddir = os.path.dirname(__file__)
+    # Specifying builddir here itself to simulate passing in a run command
+    # builddir passed in the function will be an argument for the run command
+    args_list = ['-p', '75000:80', builddir, 'ls']
+
+    assert not validate_arguments(builddir, args_list, 'Invalid port mapping')
+
+
+def test_invalid_protocol_port_mapping_fail():
+    """
+    Test to check if r2d fails when an invalid protocol is specified in the port mapping
+    """
+    builddir = os.path.dirname(__file__)
+    # Specifying builddir here itself to simulate passing in a run command
+    # builddir passed in the function will be an argument for the run command
+    args_list = ['-p', '80/tpc:8000', builddir, 'ls']
+
+    assert not validate_arguments(builddir, args_list, 'Invalid port mapping')
+
+
+def test_invalid_container_port_protocol_mapping_fail():
+    """
+    Test to check if r2d fails when an invalid protocol is specified in the container port in port mapping
+    """
+    builddir = os.path.dirname(__file__)
+    # Specifying builddir here itself to simulate passing in a run command
+    # builddir passed in the function will be an argument for the run command
+    args_list = ['-p', '80:8000/upd', builddir, 'ls']
+
+    assert not validate_arguments(builddir, args_list, 'Invalid port mapping')

--- a/tests/ports.py
+++ b/tests/ports.py
@@ -1,0 +1,137 @@
+"""
+Test Port mappings work on running non-jupyter workflows
+"""
+import subprocess
+import requests
+import time
+import os
+import tempfile
+import signal
+import random
+
+
+def read_port_mapping_response(host, port, protocol = None):
+    """
+    Deploy container and test if port mappings work as expected
+
+    Args:
+        host: the host interface to bind to.
+        port: the random host port to bind to
+        protocol: the protocol to use valid values /tcp or /udp
+    """
+    builddir = os.path.dirname(__file__)
+    port_protocol = '8000'
+    if protocol:
+        port_protocol += protocol
+    host_port = port
+    if host:
+        host_port = host + ':' + port
+    else:
+        host = 'localhost'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        username = os.getlogin()
+
+        # Deploy a test container using r2d in a subprocess
+        # Added the -v volumes to be able to poll for changes within the container from the
+        # host (In this case container starting up)
+        proc = subprocess.Popen(['repo2docker',
+                                 '-p',
+                                 host_port + ':' + port_protocol,
+                                 '-v', '{}:/home'.format(tmpdir),
+                                 '--user-id', str(os.geteuid()),
+                                 '--user-name', username,
+                                 '.',
+                                 '/bin/bash', '-c', 'echo \'hi\' > /home/ts && python -m http.server 8000'],
+                                 cwd=builddir + "/../",
+                                 stderr=subprocess.STDOUT)
+        try:
+            # Wait till docker builds image and starts up
+            while not os.path.exists(os.path.join(tmpdir, 'ts')):
+                if proc.poll() is not None:
+                    # Break loop on errors from the subprocess
+                    raise Exception("Process running r2d exited")
+
+            # Sleep to wait for python http server to start
+            time.sleep(20)
+            resp = requests.request("GET", 'http://' + host + ':' + port)
+
+            # Check if the response is correct
+            assert b'Directory listing' in resp.content
+        finally:
+            if proc.poll() is None:
+                # If the subprocess running the container is still running, interrupt it to close it
+                os.kill(proc.pid, signal.SIGINT)
+                time.sleep(10)
+
+
+def test_all_port_mapping_response():
+    """
+    Deploy container and test if all port expose works as expected
+    """
+    builddir = os.path.dirname(__file__)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        username = os.getlogin()
+
+        # Deploy a test container using r2d in a subprocess
+        # Added the -v volumes to be able to poll for changes within the container from the
+        # host (In this case container starting up)
+        proc = subprocess.Popen(['repo2docker',
+                                 "--image-name",
+                                 "testallport:0.1",
+                                 '-P',
+                                 '-v', '{}:/home'.format(tmpdir),
+                                 '--user-id', str(os.geteuid()),
+                                 '--user-name', username,
+                                 '.',
+                                 '/bin/bash', '-c', 'echo \'hi\' > /home/ts && python -m http.server 52000'],
+                                 cwd=builddir + "/../",
+                                 stderr=subprocess.STDOUT)
+
+        try:
+            # Wait till docker builds image and starts up
+            while not os.path.exists(os.path.join(tmpdir, 'ts')):
+                if proc.poll() is not None:
+                    # Break loop on errors from the subprocess
+                    raise Exception("Process running r2d exited")
+
+            # Sleep to wait for python http server to start
+            time.sleep(20)
+            port = subprocess.check_output("docker ps -f ancestor=testallport:0.1 --format '{{.Ports}}' | cut -f 1 -d - | cut -d: -f 2",
+                                            shell=True).decode("utf-8")
+            port = port.strip("\n\t")
+            resp = requests.request("GET", 'http://localhost' + ':' + port)
+
+            # Check if the response is correct
+            assert b'Directory listing' in resp.content
+        finally:
+            if proc.poll() is None:
+                # If the subprocess running the container is still running, interrupt it to close it
+                os.kill(proc.pid, signal.SIGINT)
+                time.sleep(10)
+
+
+def test_port_mapping_random_port():
+    """
+    Test a simple random port bind
+    """
+    port = str(random.randint(50000, 51000))
+    host = None
+    read_port_mapping_response(host, port)
+
+
+def test_port_mapping_particular_interface():
+    """
+    Test if binding to a single interface is possible
+    """
+    port = str(random.randint(50000, 51000))
+    host = '127.0.0.1'
+    read_port_mapping_response(host, port)
+
+
+def test_port_mapping_protocol():
+    """
+    Test if a particular protocol can be used
+    """
+    port = str(random.randint(50000, 51000))
+    host = None
+    read_port_mapping_response(host, port, '/tcp')


### PR DESCRIPTION
One question is I have removed the get random port method from repo2docker as docker-py supports assigning random ports if None is passed in the dict 
https://github.com/docker/docker-py/blob/190d95c61cc0440108de8a0c14027e72c56b6772/docker/models/containers.py#L596
Do we need to have the default run_cmd jupyter notebook started in the same port inside the container as outside? Is there are necessity for that?
Closes #100 