### PR TITLE
Fix indentation causing only last line of apt.txt to be parsed

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -443,7 +443,7 @@ class BaseImage(BuildPack):
                     if not re.match(r"^[a-z0-9.+-]+", package):
                         raise ValueError("Found invalid package name {} in "
                                          "apt.txt".format(package))
-                extra_apt_packages.append(package)
+                    extra_apt_packages.append(package)
 
             assemble_scripts.append((
                 'root',

--- a/tests/venv/apt-packages/apt.txt
+++ b/tests/venv/apt-packages/apt.txt
@@ -4,5 +4,5 @@ gfortran
 
 # testing to see if all packages get installed
 rolldice
-moo
+sl
 

--- a/tests/venv/apt-packages/apt.txt
+++ b/tests/venv/apt-packages/apt.txt
@@ -3,6 +3,6 @@
 gfortran
 
 # testing to see if all packages get installed
-rolldice
-sl
+unp
+byacc
 

--- a/tests/venv/apt-packages/apt.txt
+++ b/tests/venv/apt-packages/apt.txt
@@ -1,3 +1,8 @@
 # testing to skip comments in this file
 
 gfortran
+
+# testing to see if all packages get installed
+rolldice
+moo
+

--- a/tests/venv/apt-packages/verify
+++ b/tests/venv/apt-packages/verify
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 which gfortran
+which rolldice
+which sl

--- a/tests/venv/apt-packages/verify
+++ b/tests/venv/apt-packages/verify
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 which gfortran
-which rolldice
-which sl
+which unp
+which byacc


### PR DESCRIPTION
Parsing apt.txt was only appending the last package to the list of packages to install. Fixed indentation to append all packages.