### PR TITLE
Stop using alpine base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.6.3-alpine3.6
+FROM python:3.6.3
 
 # Git is required for repo2docker to work
-RUN apk add --no-cache git
+#RUN apk add --no-cache git
 
 RUN mkdir /tmp/src
 ADD . /tmp/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.6.3
 
-# Git is required for repo2docker to work
-#RUN apk add --no-cache git
-
 RUN mkdir /tmp/src
 ADD . /tmp/src
 RUN pip3 install --no-cache-dir /tmp/src


### PR DESCRIPTION
- It is currently breaking the build, since alpine does not
  support binary wheels & we introduced ruamel.yaml which has
  binary dependencies
- pip / python on alpine is broken wrt symlinks, making local
  testing harder