### PR TITLE
refreeze conda environments

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-03 15:33:55 UTC
+# Frozen on 2018-01-08 13:27:23 UTC
 name: r2d
 channels:
 - conda-forge
@@ -19,7 +19,7 @@ dependencies:
 - jedi=0.10.2=py36_0
 - jinja2=2.10=py36_0
 - jsonschema=2.6.0=py36_0
-- jupyter_client=5.2.0=py36_0
+- jupyter_client=5.2.1=py36_0
 - jupyter_core=4.4.0=py_0
 - jupyterlab=0.30.6=py36_0
 - jupyterlab_launcher=0.6.0=py36_0
@@ -43,7 +43,7 @@ dependencies:
 - python-dateutil=2.6.1=py36_0
 - pyzmq=16.0.2=py36_2
 - readline=7.0=0
-- setuptools=38.2.4=py36_0
+- setuptools=38.4.0=py36_0
 - simplegeneric=0.8.1=py36_0
 - six=1.11.0=py36_1
 - sqlite=3.20.1=2
@@ -54,7 +54,7 @@ dependencies:
 - traitlets=4.3.2=py36_0
 - wcwidth=0.1.7=py36_0
 - webencodings=0.5=py36_0
-- wheel=0.30.0=py_1
+- wheel=0.30.0=py36_2
 - widgetsnbextension=2.0.1=py36_0
 - xz=5.2.3=0
 - zeromq=4.2.1=1

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -4,6 +4,7 @@ name: r2d
 channels:
 - conda-forge
 - defaults
+- conda-forge/label/broken
 dependencies:
 - bleach=2.0.0=py36_0
 - ca-certificates=2017.11.5=0

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-03 16:56:23 UTC
+# Frozen on 2018-01-08 13:23:37 UTC
 name: r2d
 channels:
 - conda-forge
@@ -15,7 +15,7 @@ dependencies:
 - ipykernel=4.7.0=py27_0
 - ipython=5.5.0=py27_0
 - ipython_genutils=0.2.0=py27_0
-- jupyter_client=5.2.0=py27_0
+- jupyter_client=5.2.1=py27_0
 - jupyter_core=4.4.0=py_0
 - libsodium=1.0.15=1
 - ncurses=5.9=10
@@ -32,7 +32,7 @@ dependencies:
 - pyzmq=16.0.2=py27_2
 - readline=7.0=0
 - scandir=1.6=py27_0
-- setuptools=38.2.4=py27_0
+- setuptools=38.4.0=py27_0
 - simplegeneric=0.8.1=py27_0
 - singledispatch=3.4.0.3=py27_0
 - six=1.11.0=py27_1
@@ -42,7 +42,7 @@ dependencies:
 - tornado=4.5.2=py27_0
 - traitlets=4.3.2=py27_0
 - wcwidth=0.1.7=py27_0
-- wheel=0.30.0=py_1
+- wheel=0.30.0=py27_2
 - zeromq=4.2.1=1
 - zlib=1.2.11=0
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-03 15:31:22 UTC
+# Frozen on 2018-01-08 13:25:03 UTC
 name: r2d
 channels:
 - conda-forge
@@ -19,7 +19,7 @@ dependencies:
 - jedi=0.10.2=py35_0
 - jinja2=2.10=py35_0
 - jsonschema=2.6.0=py35_0
-- jupyter_client=5.2.0=py35_0
+- jupyter_client=5.2.1=py35_0
 - jupyter_core=4.4.0=py_0
 - jupyterlab=0.30.6=py35_0
 - jupyterlab_launcher=0.6.0=py35_0
@@ -43,7 +43,7 @@ dependencies:
 - python-dateutil=2.6.1=py35_0
 - pyzmq=16.0.2=py35_2
 - readline=7.0=0
-- setuptools=38.2.4=py35_0
+- setuptools=38.4.0=py35_0
 - simplegeneric=0.8.1=py35_0
 - six=1.11.0=py35_1
 - sqlite=3.20.1=2
@@ -54,7 +54,7 @@ dependencies:
 - traitlets=4.3.2=py35_0
 - wcwidth=0.1.7=py35_0
 - webencodings=0.5=py35_0
-- wheel=0.30.0=py_1
+- wheel=0.30.0=py35_2
 - widgetsnbextension=2.0.1=py35_0
 - xz=5.2.3=0
 - zeromq=4.2.1=1

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -4,6 +4,7 @@ name: r2d
 channels:
 - conda-forge
 - defaults
+- conda-forge/label/broken
 dependencies:
 - bleach=2.0.0=py35_0
 - ca-certificates=2017.11.5=0

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-03 15:33:55 UTC
+# Frozen on 2018-01-08 13:27:23 UTC
 name: r2d
 channels:
 - conda-forge
@@ -19,7 +19,7 @@ dependencies:
 - jedi=0.10.2=py36_0
 - jinja2=2.10=py36_0
 - jsonschema=2.6.0=py36_0
-- jupyter_client=5.2.0=py36_0
+- jupyter_client=5.2.1=py36_0
 - jupyter_core=4.4.0=py_0
 - jupyterlab=0.30.6=py36_0
 - jupyterlab_launcher=0.6.0=py36_0
@@ -43,7 +43,7 @@ dependencies:
 - python-dateutil=2.6.1=py36_0
 - pyzmq=16.0.2=py36_2
 - readline=7.0=0
-- setuptools=38.2.4=py36_0
+- setuptools=38.4.0=py36_0
 - simplegeneric=0.8.1=py36_0
 - six=1.11.0=py36_1
 - sqlite=3.20.1=2
@@ -54,7 +54,7 @@ dependencies:
 - traitlets=4.3.2=py36_0
 - wcwidth=0.1.7=py36_0
 - webencodings=0.5=py36_0
-- wheel=0.30.0=py_1
+- wheel=0.30.0=py36_2
 - widgetsnbextension=2.0.1=py36_0
 - xz=5.2.3=0
 - zeromq=4.2.1=1

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -4,6 +4,7 @@ name: r2d
 channels:
 - conda-forge
 - defaults
+- conda-forge/label/broken
 dependencies:
 - bleach=2.0.0=py36_0
 - ca-certificates=2017.11.5=0

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -82,6 +82,9 @@ def freeze(env_file, frozen_file):
             'conda config --add channels conda-forge',
             'conda config --system --set auto_update_conda false',
             f"conda env create -v -f /r2d/{env_file} -n r2d",
+            # add conda-forge broken channel as lowest priority in case
+            # any of our frozen packages are marked as broken after freezing
+            'conda config --append channels conda-forge/label/broken',
             f"conda env export -n r2d >> /r2d/{frozen_file}",
         ])
     ])
@@ -117,5 +120,6 @@ if __name__ == '__main__':
         set_python(env_file, py)
         frozen_file = os.path.splitext(env_file)[0] + '.frozen.yml'
         freeze(env_file, frozen_file)
+
     # use last version as default
     shutil.copy(frozen_file, FROZEN_FILE)


### PR DESCRIPTION
gets a few updates, but fixes issue with noarch wheel package that has been identified as broken.

ref: https://github.com/conda-forge/wheel-feedstock/pull/9