### PR TITLE
Emergency Bump to artful

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -10,7 +10,7 @@ import re
 import docker
 
 TEMPLATE = r"""
-FROM buildpack-deps:zesty
+FROM buildpack-deps:artful
 
 # Set up locales properly
 RUN apt-get update && \
@@ -151,7 +151,6 @@ class BuildPack(LoggingConfigurable):
             # FIXME: Use npm from nodesource!
             # Everything seems to depend on npm these days, unfortunately.
             "npm",
-            "nodejs-legacy"
         },
         help="""
         Base set of apt packages that are installed for all images.

--- a/tests/external/datasci.repos.yaml
+++ b/tests/external/datasci.repos.yaml
@@ -1,5 +1,0 @@
-# A bunch of external datascience related repos we care about!
-- name: Jake's Data Science Book
-  url: https://github.com/jakevdp/PythonDataScienceHandbook
-  ref: de0cc6bd31
-  verify: python -c 'import matplotlib'

--- a/tests/memlimit/dockerfile/Dockerfile
+++ b/tests/memlimit/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM ubuntu:artful
 
 RUN apt-get update && apt-get install --yes python3
 

--- a/tests/venv/default/verify
+++ b/tests/venv/default/verify
@@ -2,5 +2,5 @@
 # Verify that the default just provides a py3 environment with jupyter
 import sys
 
-assert sys.version_info[:2] == (3, 5)
+assert sys.version_info[:2] == (3, 6)
 import jupyter

--- a/tests/venv/numpy/verify
+++ b/tests/venv/numpy/verify
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
 
-assert sys.version_info[:2] == (3, 5)
+assert sys.version_info[:2] == (3, 6)
 
 import numpy


### PR DESCRIPTION
Zesty fell out of support on Jan 13, and the packages have
started disappearing from http://archive.ubuntu.com/ubuntu/ and
other mirrors as of today. This will totally screw up our
build processes whenever it hits the mirror we use.