### PR TITLE
Add nteract jupyter extension to requirements.txt based setups

### DIFF
--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -55,7 +55,8 @@ class PythonBuildPack(BuildPack):
                 r"""
                 pip install --no-cache-dir -r /tmp/requirements.frozen.txt && \
                 jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
-                jupyter serverextension enable --py jupyterlab --sys-prefix
+                jupyter serverextension enable --py jupyterlab --sys-prefix && \
+                jupyter serverextension enable nteract_on_jupyter --sys-prefix
                 """
             )
         ]

--- a/repo2docker/buildpacks/python/requirements.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements.frozen.txt
@@ -1,17 +1,17 @@
 # AUTO GENERATED FROM requirements.txt, DO NOT MANUALLY MODIFY
-# Frozen on Sat Dec 16 22:12:51 UTC 2017
+# Frozen on Wed Jan 31 21:54:41 UTC 2018
 bleach==2.1.2
-decorator==4.1.2
+decorator==4.2.1
 entrypoints==0.2.3
 html5lib==1.0.1
-ipykernel==4.7.0
+ipykernel==4.8.0
 ipython-genutils==0.2.0
 ipython==6.2.1
 ipywidgets==6.0.1
 jedi==0.11.1
 Jinja2==2.10
 jsonschema==2.6.0
-jupyter-client==5.1.0
+jupyter-client==5.2.2
 jupyter-core==4.4.0
 jupyterlab-launcher==0.6.0
 jupyterlab==0.30.6
@@ -20,6 +20,7 @@ mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0
 notebook==5.2.2
+nteract-on-jupyter==1.3.1
 pandocfilters==1.4.2
 parso==0.1.1
 pexpect==4.3.1
@@ -28,12 +29,12 @@ prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0
 python-dateutil==2.6.1
-pyzmq==16.0.3
+pyzmq==16.0.4
 simplegeneric==0.8.1
 six==1.11.0
 terminado==0.8.1
 testpath==0.3.1
-tornado==4.5.2
+tornado==4.5.3
 traitlets==4.3.2
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/repo2docker/buildpacks/python/requirements.txt
+++ b/repo2docker/buildpacks/python/requirements.txt
@@ -1,3 +1,4 @@
 notebook==5.2.2
 ipywidgets==6.0.1
 jupyterlab==0.30.6
+nteract_on_jupyter==1.3.1

--- a/repo2docker/buildpacks/python/requirements2.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements2.frozen.txt
@@ -1,14 +1,14 @@
 # AUTO GENERATED FROM requirements2.txt, DO NOT MANUALLY MODIFY
-# Frozen on Sat Dec 16 22:13:15 UTC 2017
+# Frozen on Wed Jan 31 21:55:07 UTC 2018
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
-certifi==2017.11.5
-decorator==4.1.2
+certifi==2018.1.18
+decorator==4.2.1
 enum34==1.1.6
 ipykernel==4.6.1
 ipython-genutils==0.2.0
 ipython==5.5.0
-jupyter-client==5.1.0
+jupyter-client==5.2.2
 jupyter-core==4.4.0
 pathlib2==2.3.0
 pexpect==4.3.1
@@ -17,11 +17,11 @@ prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0
 python-dateutil==2.6.1
-pyzmq==16.0.3
+pyzmq==16.0.4
 scandir==1.6
 simplegeneric==0.8.1
 singledispatch==3.4.0.3
 six==1.11.0
-tornado==4.5.2
+tornado==4.5.3
 traitlets==4.3.2
 wcwidth==0.1.7


### PR DESCRIPTION
Didn't add to conda, since there is currently no way to add
pip packages to our conda frozen setup (due to
https://github.com/conda/conda/pull/6438).

This means nteract will be available only when used with
requirement.txt, and not when used with environment.yml files.