### PR TITLE
Refactor (most) traitlets out of buildpacks

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -183,12 +183,11 @@ class BuildPack(LoggingConfigurable):
         """
         return []
 
-    labels = Dict(
-        {},
-        help="""
+    def get_labels(self):
+        """
         Docker labels to set on the built image.
         """
-    )
+        return {}
 
     build_script_files = Dict(
         {},
@@ -283,15 +282,12 @@ class BuildPack(LoggingConfigurable):
         for resolving them.
         """
         result = BuildPack(parent=self)
-        labels = {}
-        labels.update(self.labels)
-        labels.update(other.labels)
-        result.labels = labels
         # FIXME: Temporary hack so we can refactor this piece by piece instead of all at once!
         result.get_packages = lambda: self.get_packages().union(other.get_packages())
         result.get_base_packages = lambda: self.get_base_packages().union(other.get_base_packages())
         result.get_path = lambda: self.get_path() + other.get_path()
         result.get_env = lambda: self.get_env() + other.get_env()
+        result.get_labels = lambda: self.get_labels() + other.get_labels()
 
         result.build_scripts = self.build_scripts + other.build_scripts
         result.assemble_scripts = (self.assemble_scripts +
@@ -350,7 +346,7 @@ class BuildPack(LoggingConfigurable):
             packages=sorted(self.get_packages()),
             path=self.get_path(),
             env=self.get_env(),
-            labels=self.labels,
+            labels=self.get_labels(),
             build_script_directives=build_script_directives,
             assemble_script_directives=assemble_script_directives,
             build_script_files=self.build_script_files,

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -222,9 +222,8 @@ class BuildPack(LoggingConfigurable):
         """
         return []
 
-    assemble_scripts = List(
-        [],
-        help="""
+    def get_assemble_scripts(self):
+        """
         Ordered list of shell script snippets to build the repo into the image.
 
         A list of tuples, where the first item is a username & the
@@ -247,7 +246,7 @@ class BuildPack(LoggingConfigurable):
         You can use environment variable substitutions in both the
         username and the execution script.
         """
-    )
+        return []
 
     post_build_scripts = List(
         [],
@@ -295,9 +294,8 @@ class BuildPack(LoggingConfigurable):
         result.get_labels = lambda: _merge_dicts(self.get_labels(), other.get_labels())
         result.get_build_script_files = lambda: _merge_dicts(self.get_build_script_files(), other.get_build_script_files())
         result.get_build_scripts = lambda: self.get_build_scripts() + other.get_build_scripts()
+        result.get_assemble_scripts = lambda: self.get_assemble_scripts() + other.get_assemble_scripts()
 
-        result.assemble_scripts = (self.assemble_scripts +
-                                   other.assemble_scripts)
         result.post_build_scripts = (self.post_build_scripts +
                                      other.post_build_scripts)
 
@@ -335,7 +333,7 @@ class BuildPack(LoggingConfigurable):
 
         assemble_script_directives = []
         last_user = 'root'
-        for user, script in self.assemble_scripts:
+        for user, script in self.get_assemble_scripts():
             if last_user != user:
                 assemble_script_directives.append("USER {}".format(user))
                 last_user = user

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -410,9 +410,10 @@ class BaseImage(BuildPack):
     name = "repo2docker"
     version = "0.1"
 
-    env = [
-        ("APP_BASE", "/srv")
-    ]
+    def get_env(self):
+        return [
+            ("APP_BASE", "/srv")
+        ]
 
     def detect(self):
         return True

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -248,9 +248,8 @@ class BuildPack(LoggingConfigurable):
         """
         return []
 
-    post_build_scripts = List(
-        [],
-        help="""
+    def get_post_build_scripts(self):
+        """
         An ordered list of executable scripts to execute after build.
 
         Is run as a non-root user, and must be executable. Used for doing
@@ -259,7 +258,7 @@ class BuildPack(LoggingConfigurable):
         The scripts should be as deterministic as possible - running it twice
         should not produce different results!
         """
-    )
+        return []
 
     name = Unicode(
         help="""
@@ -295,9 +294,8 @@ class BuildPack(LoggingConfigurable):
         result.get_build_script_files = lambda: _merge_dicts(self.get_build_script_files(), other.get_build_script_files())
         result.get_build_scripts = lambda: self.get_build_scripts() + other.get_build_scripts()
         result.get_assemble_scripts = lambda: self.get_assemble_scripts() + other.get_assemble_scripts()
+        result.get_post_build_scripts = lambda: self.get_post_build_scripts() + other.get_post_build_scripts()
 
-        result.post_build_scripts = (self.post_build_scripts +
-                                     other.post_build_scripts)
 
         result.name = "{}-{}".format(self.name, other.name)
 
@@ -350,7 +348,7 @@ class BuildPack(LoggingConfigurable):
             assemble_script_directives=assemble_script_directives,
             build_script_files=self.get_build_script_files(),
             base_packages=sorted(self.get_base_packages()),
-            post_build_scripts=self.post_build_scripts,
+            post_build_scripts=self.get_post_build_scripts(),
         )
 
     def build(self, image_spec, memory_limit, build_args):
@@ -451,8 +449,7 @@ class BaseImage(BuildPack):
             pass
         return assemble_scripts
 
-    @default('post_build_scripts')
-    def setup_post_build_scripts(self):
+    def get_post_build_scripts(self):
         post_build = self.binder_path('postBuild')
         if os.path.exists(post_build):
             if not stat.S_IXUSR & os.stat(post_build).st_mode:

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -162,9 +162,8 @@ class BuildPack(LoggingConfigurable):
             "npm",
         }
 
-    env = List(
-        [],
-        help="""
+    def get_env(self):
+        """
         Ordered list of environment variables to be set for this image.
 
         Ordered so that environment variables can use other environment
@@ -173,17 +172,16 @@ class BuildPack(LoggingConfigurable):
         Expects tuples, with the first item being the environment variable
         name and the second item being the value.
         """
-    )
+        return []
 
-    path = List(
-        [],
-        help="""
+    def get_path(self):
+        """
         Ordered list of file system paths to look for executables in.
 
         Just sets the PATH environment variable. Separated out since
         it is very commonly set by various buildpacks.
         """
-    )
+        return []
 
     labels = Dict(
         {},
@@ -292,10 +290,9 @@ class BuildPack(LoggingConfigurable):
         # FIXME: Temporary hack so we can refactor this piece by piece instead of all at once!
         result.get_packages = lambda: self.get_packages().union(other.get_packages())
         result.get_base_packages = lambda: self.get_base_packages().union(other.get_base_packages())
+        result.get_path = lambda: self.get_path() + other.get_path()
+        result.get_env = lambda: self.get_env() + other.get_env()
 
-        result.path = self.path + other.path
-        # FIXME: Deduplicate Env
-        result.env = self.env + other.env
         result.build_scripts = self.build_scripts + other.build_scripts
         result.assemble_scripts = (self.assemble_scripts +
                                    other.assemble_scripts)
@@ -351,8 +348,8 @@ class BuildPack(LoggingConfigurable):
 
         return t.render(
             packages=sorted(self.get_packages()),
-            path=self.path,
-            env=self.env,
+            path=self.get_path(),
+            env=self.get_env(),
             labels=self.labels,
             build_script_directives=build_script_directives,
             assemble_script_directives=assemble_script_directives,

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -417,8 +417,7 @@ class BaseImage(BuildPack):
     def detect(self):
         return True
 
-    @default('assemble_scripts')
-    def setup_assembly(self):
+    def get_assemble_scripts(self):
         assemble_scripts = []
         try:
             with open(self.binder_path('apt.txt')) as f:

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -78,9 +78,11 @@ class CondaBuildPack(BuildPack):
         Will return 'x.y' if found, or Falsy '' if not.
         """
         if not hasattr(self, '_python_version'):
+            py_version = None
             environment_yml = self.binder_path('environment.yml')
             if not os.path.exists(environment_yml):
                 self._python_version = ''
+                return self._python_version
             with open(environment_yml) as f:
                 env = YAML().load(f)
                 for dep in env.get('dependencies', []):

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -19,12 +19,14 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 class CondaBuildPack(BuildPack):
     name = "conda"
     version = "0.1"
-    env = [
-        ('CONDA_DIR', '${APP_BASE}/conda'),
-        ('NB_PYTHON_PREFIX', '${CONDA_DIR}'),
-    ]
+    def get_env(self):
+        return [
+            ('CONDA_DIR', '${APP_BASE}/conda'),
+            ('NB_PYTHON_PREFIX', '${CONDA_DIR}'),
+        ]
 
-    path = ['${CONDA_DIR}/bin']
+    def get_path(self):
+        return ['${CONDA_DIR}/bin']
 
     build_scripts = [
         (

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -48,7 +48,7 @@ class CondaBuildPack(BuildPack):
         files = {
             'conda/install-miniconda.bash': '/tmp/install-miniconda.bash',
         }
-        py_version = self.python_version
+        py_version = self.get_python_version()
         self.log.info("Building conda environment for python=%s" % py_version)
         # Select the frozen base environment based on Python version.
         # avoids expensive and possibly conflicting upgrades when changing
@@ -70,45 +70,42 @@ class CondaBuildPack(BuildPack):
         files['conda/' + frozen_name] = '/tmp/environment.yml'
         return files
 
-    @property
-    def python_version(self):
+    def get_python_version(self):
         """
         Detect the Python version for a given environment.yml
 
         Will return 'x.y' if found, or Falsy '' if not.
         """
-        if not hasattr(self, '_python_version'):
-            py_version = None
-            environment_yml = self.binder_path('environment.yml')
-            if not os.path.exists(environment_yml):
-                self._python_version = ''
-                return self._python_version
-            with open(environment_yml) as f:
-                env = YAML().load(f)
-                for dep in env.get('dependencies', []):
-                    if not isinstance(dep, str):
-                        continue
-                    match = PYTHON_REGEX.match(dep)
-                    if not match:
-                        continue
-                    py_version = match.group(1)
-                    break
+        py_version = None
+        environment_yml = self.binder_path('environment.yml')
+        if not os.path.exists(environment_yml):
+            return ''
+        with open(environment_yml) as f:
+            env = YAML().load(f)
+            for dep in env.get('dependencies', []):
+                if not isinstance(dep, str):
+                    continue
+                match = PYTHON_REGEX.match(dep)
+                if not match:
+                    continue
+                py_version = match.group(1)
+                break
 
-            # extract major.minor
-            if py_version:
-                if len(py_version) == 1:
-                    self._python_version = self.major_pythons.get(py_version[0])
-                else:
-                    # return major.minor
-                    self._python_version = '.'.join(py_version[:2])
+        # extract major.minor
+        if py_version:
+            if len(py_version) == 1:
+                return self.major_pythons.get(py_version[0])
+            else:
+                # return major.minor
+                return '.'.join(py_version[:2])
 
-            self._python_version = ''
-        return self._python_version
+        return ''
 
     @property
     def py2(self):
         """Am I building a Python 2 kernel environment?"""
-        return self.python_version and self.python_version.split('.')[0] == '2'
+        python_version = self.get_python_version()
+        return python_version and python_version.split('.')[0] == '2'
 
     def get_assemble_scripts(self):
         assembly_scripts = []

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -108,8 +108,7 @@ class CondaBuildPack(BuildPack):
         """Am I building a Python 2 kernel environment?"""
         return self.python_version and self.python_version.split('.')[0] == '2'
 
-    #@default('assemble_scripts')
-    def setup_assembly(self):
+    def get_assemble_scripts(self):
         assembly_scripts = []
         environment_yml = self.binder_path('environment.yml')
         env_name = 'kernel' if self.py2 else 'root'

--- a/repo2docker/buildpacks/julia.py
+++ b/repo2docker/buildpacks/julia.py
@@ -9,17 +9,18 @@ from .base import BuildPack
 class JuliaBuildPack(BuildPack):
     name = "julia"
     version = "0.1"
-    env = [
-        ('JULIA_PATH', '${APP_BASE}/julia'),
-        ('JULIA_HOME', '${JULIA_PATH}/bin'),
-        ('JULIA_PKGDIR', '${JULIA_PATH}/pkg'),
-        ('JULIA_VERSION', '0.6.0'),
-        ('JUPYTER', '${NB_PYTHON_PREFIX}/bin/jupyter')
-    ]
 
-    path = [
-        '${JULIA_PATH}/bin'
-    ]
+    def get_env(self):
+        return [
+            ('JULIA_PATH', '${APP_BASE}/julia'),
+            ('JULIA_HOME', '${JULIA_PATH}/bin'),
+            ('JULIA_PKGDIR', '${JULIA_PATH}/pkg'),
+            ('JULIA_VERSION', '0.6.0'),
+            ('JUPYTER', '${NB_PYTHON_PREFIX}/bin/jupyter')
+        ]
+
+    def get_path(self):
+        return ['${JULIA_PATH}/bin']
 
     build_scripts = [
         (

--- a/repo2docker/buildpacks/julia.py
+++ b/repo2docker/buildpacks/julia.py
@@ -22,31 +22,32 @@ class JuliaBuildPack(BuildPack):
     def get_path(self):
         return ['${JULIA_PATH}/bin']
 
-    build_scripts = [
-        (
-            "root",
-            r"""
-            mkdir -p ${JULIA_PATH} && \
-            curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | tar -xz -C ${JULIA_PATH} --strip-components 1
-            """
-        ),
-        (
-            "root",
-            r"""
-            mkdir -p ${JULIA_PKGDIR} && \
-            chown ${NB_USER}:${NB_USER} ${JULIA_PKGDIR}
-            """
-        ),
-        (
-            "${NB_USER}",
-            # HACK: Can't seem to tell IJulia to install in sys-prefix
-            # FIXME: Find way to get it to install under /srv and not $HOME?
-            r"""
-            julia -e 'Pkg.init(); Pkg.add("IJulia"); using IJulia;' && \
-            mv ${HOME}/.local/share/jupyter/kernels/julia-0.6  ${NB_PYTHON_PREFIX}/share/jupyter/kernels/julia-0.6
-            """
-        )
-    ]
+    def get_build_scripts(self):
+        return [
+            (
+                "root",
+                r"""
+                mkdir -p ${JULIA_PATH} && \
+                curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | tar -xz -C ${JULIA_PATH} --strip-components 1
+                """
+            ),
+            (
+                "root",
+                r"""
+                mkdir -p ${JULIA_PKGDIR} && \
+                chown ${NB_USER}:${NB_USER} ${JULIA_PKGDIR}
+                """
+            ),
+            (
+                "${NB_USER}",
+                # HACK: Can't seem to tell IJulia to install in sys-prefix
+                # FIXME: Find way to get it to install under /srv and not $HOME?
+                r"""
+                julia -e 'Pkg.init(); Pkg.add("IJulia"); using IJulia;' && \
+                mv ${HOME}/.local/share/jupyter/kernels/julia-0.6  ${NB_PYTHON_PREFIX}/share/jupyter/kernels/julia-0.6
+                """
+            )
+        ]
 
     @default('assemble_scripts')
     def setup_assembly(self):

--- a/repo2docker/buildpacks/julia.py
+++ b/repo2docker/buildpacks/julia.py
@@ -49,8 +49,7 @@ class JuliaBuildPack(BuildPack):
             )
         ]
 
-    @default('assemble_scripts')
-    def setup_assembly(self):
+    def get_assemble_scripts(self):
         require = self.binder_path('REQUIRE')
         return [(
             "${NB_USER}",

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -10,11 +10,12 @@ class PythonBuildPack(BuildPack):
     name = "python3.5"
     version = "0.1"
 
-    packages = {
-        'python3',
-        'python3-venv',
-        'python3-dev',
-    }
+    def get_packages(self):
+        return {
+            'python3',
+            'python3-venv',
+            'python3-dev',
+        }
 
     env = [
         ("VENV_PATH", "${APP_BASE}/venv"),
@@ -88,7 +89,8 @@ class Python2BuildPack(BuildPack):
     name = "python2.7"
     version = "0.1"
 
-    packages = {
+    def get_packages(self):
+        return {
         'python',
         'python-dev',
         'virtualenv'

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -60,8 +60,7 @@ class PythonBuildPack(BuildPack):
             )
         ]
 
-    @default('assemble_scripts')
-    def setup_assembly(self):
+    def get_assemble_scripts(self):
         # If we have a runtime.txt & that's set to python-2.7,
         # we will *not* install requirements.txt but will find &
         # install a requirements3.txt file if it exists.
@@ -140,8 +139,7 @@ class Python2BuildPack(BuildPack):
             )
         ]
 
-    @default('assemble_scripts')
-    def setup_assembly(self):
+    def get_assemble_scripts(self):
         return [
             (
                 '${NB_USER}',

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -30,33 +30,35 @@ class PythonBuildPack(BuildPack):
         ]
 
 
-    build_script_files = {
-        'python/requirements.frozen.txt': '/tmp/requirements.frozen.txt',
-    }
+    def get_build_script_files(self):
+        return {
+            'python/requirements.frozen.txt': '/tmp/requirements.frozen.txt',
+        }
 
-    build_scripts = [
-        (
-            "root",
-            r"""
-            mkdir -p ${VENV_PATH} && \
-            chown -R ${NB_USER}:${NB_USER} ${VENV_PATH}
-            """
-        ),
-        (
-            "${NB_USER}",
-            r"""
-            python3 -m venv ${VENV_PATH}
-            """
-        ),
-        (
-            "${NB_USER}",
-            r"""
-            pip install --no-cache-dir -r /tmp/requirements.frozen.txt && \
-            jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
-            jupyter serverextension enable --py jupyterlab --sys-prefix
-            """
-        )
-    ]
+    def get_build_scripts(self):
+        return [
+            (
+                "root",
+                r"""
+                mkdir -p ${VENV_PATH} && \
+                chown -R ${NB_USER}:${NB_USER} ${VENV_PATH}
+                """
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                python3 -m venv ${VENV_PATH}
+                """
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                pip install --no-cache-dir -r /tmp/requirements.frozen.txt && \
+                jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
+                jupyter serverextension enable --py jupyterlab --sys-prefix
+                """
+            )
+        ]
 
     @default('assemble_scripts')
     def setup_assembly(self):
@@ -98,9 +100,6 @@ class Python2BuildPack(BuildPack):
         'virtualenv'
     }
 
-    build_script_files = {
-        'python/requirements2.frozen.txt': '/tmp/requirements2.frozen.txt',
-    }
 
     def get_env(self):
         return [
@@ -112,28 +111,34 @@ class Python2BuildPack(BuildPack):
             "${VENV2_PATH}/bin"
         ]
 
-    build_scripts = [
-        (
-            "root",
-            r"""
-            mkdir -p ${VENV2_PATH} && \
-            chown -R ${NB_USER}:${NB_USER} ${VENV2_PATH}
-            """
-        ),
-        (
-            "${NB_USER}",
-            r"""
-            virtualenv -p python2 ${VENV2_PATH}
-            """
-        ),
-        (
-            "${NB_USER}",
-            r"""
-            pip2 install --no-cache-dir -r /tmp/requirements2.frozen.txt && \
-            python2 -m ipykernel install --prefix=${NB_PYTHON_PREFIX}
-            """
-        )
-    ]
+    def get_build_script_files(self):
+        return {
+            'python/requirements2.frozen.txt': '/tmp/requirements2.frozen.txt',
+        }
+
+    def get_build_scripts(self):
+        return [
+            (
+                "root",
+                r"""
+                mkdir -p ${VENV2_PATH} && \
+                chown -R ${NB_USER}:${NB_USER} ${VENV2_PATH}
+                """
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                virtualenv -p python2 ${VENV2_PATH}
+                """
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                pip2 install --no-cache-dir -r /tmp/requirements2.frozen.txt && \
+                python2 -m ipykernel install --prefix=${NB_PYTHON_PREFIX}
+                """
+            )
+        ]
 
     @default('assemble_scripts')
     def setup_assembly(self):

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -17,15 +17,17 @@ class PythonBuildPack(BuildPack):
             'python3-dev',
         }
 
-    env = [
-        ("VENV_PATH", "${APP_BASE}/venv"),
-        # Prefix to use for installing kernels and finding jupyter binary
-        ("NB_PYTHON_PREFIX", "${VENV_PATH}"),
-    ]
+    def get_env(self):
+        return [
+            ("VENV_PATH", "${APP_BASE}/venv"),
+            # Prefix to use for installing kernels and finding jupyter binary
+            ("NB_PYTHON_PREFIX", "${VENV_PATH}"),
+        ]
 
-    path = [
-        "${VENV_PATH}/bin"
-    ]
+    def get_path(self):
+        return [
+            "${VENV_PATH}/bin"
+        ]
 
 
     build_script_files = {
@@ -100,13 +102,15 @@ class Python2BuildPack(BuildPack):
         'python/requirements2.frozen.txt': '/tmp/requirements2.frozen.txt',
     }
 
-    env = [
-        ('VENV2_PATH', '${APP_BASE}/venv2')
-    ]
+    def get_env(self):
+        return [
+            ('VENV2_PATH', '${APP_BASE}/venv2')
+        ]
 
-    path = [
-        "${VENV2_PATH}/bin"
-    ]
+    def get_path(self):
+        return [
+            "${VENV2_PATH}/bin"
+        ]
 
     build_scripts = [
         (

--- a/tests/venv/apt-packages/verify
+++ b/tests/venv/apt-packages/verify
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 which gfortran
 which unp
 which byacc


### PR DESCRIPTION
This is a 'pure' refactor in the traditional sense of the word. We will
change the internals of how buildpacks are done from Traitlets
to using simple methods in classes + (possibly) inheritance,
but will not touch our tests - this should give us a high degree
of confidence that it won't change behavior. This will thus
be a straight port of current behavior from traitlets to classes,
with no new added functionality or ancillary cleanup.

See #191 for more discussion.

The two traitlets left are `name` and `components`. The former is 
used for logging and the latter for chaining `detect` methods together.
After this PR is merged, I'll make another one that replaces our
composing with simple linear inheritance. At that point, we can get rid
of both these traitlets. I wanted to make this PR be purely 'mechanical'
refactors, to make it easier to review.
