### PR TITLE
add nteract-on-jupyter to conda

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,64 +1,67 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-11 02:59:03 UTC
+# Frozen on 2018-02-01 12:30:02 UTC
 name: r2d
 channels:
-- conda-forge
-- defaults
-- conda-forge/label/broken
+  - conda-forge
+  - defaults
+  - conda-forge/label/broken
 dependencies:
-- bleach=2.0.0=py36_0
-- ca-certificates=2017.11.5=0
-- certifi=2017.11.5=py36_0
-- decorator=4.1.2=py36_0
-- entrypoints=0.2.3=py36_1
-- gmp=6.1.2=0
-- html5lib=1.0.1=py_0
-- ipykernel=4.7.0=py36_0
-- ipython=6.2.1=py36_1
-- ipython_genutils=0.2.0=py36_0
-- ipywidgets=6.0.1=py36_0
-- jedi=0.10.2=py36_0
-- jinja2=2.10=py36_0
-- jsonschema=2.6.0=py36_0
-- jupyter_client=5.2.1=py36_0
-- jupyter_core=4.4.0=py_0
-- jupyterlab=0.30.6=py36_0
-- jupyterlab_launcher=0.6.0=py36_0
-- libsodium=1.0.15=1
-- markupsafe=1.0=py36_0
-- mistune=0.8.3=py_0
-- nbconvert=5.3.1=py_1
-- nbformat=4.4.0=py36_0
-- ncurses=5.9=10
-- notebook=5.2.2=py36_1
-- openssl=1.0.2n=0
-- pandoc=2.1=0
-- pandocfilters=1.4.1=py36_0
-- pexpect=4.3.1=py36_0
-- pickleshare=0.7.4=py36_0
-- pip=9.0.1=py36_1
-- prompt_toolkit=1.0.15=py36_0
-- ptyprocess=0.5.2=py36_0
-- pygments=2.2.0=py36_0
-- python=3.6.4=0
-- python-dateutil=2.6.1=py36_0
-- pyzmq=16.0.2=py36_3
-- readline=7.0=0
-- setuptools=38.4.0=py36_0
-- simplegeneric=0.8.1=py36_0
-- six=1.11.0=py36_1
-- sqlite=3.20.1=2
-- terminado=0.8.1=py36_0
-- testpath=0.3.1=py36_0
-- tk=8.6.7=0
-- tornado=4.5.3=py36_0
-- traitlets=4.3.2=py36_0
-- wcwidth=0.1.7=py36_0
-- webencodings=0.5=py36_0
-- wheel=0.30.0=py36_2
-- widgetsnbextension=2.0.1=py36_0
-- xz=5.2.3=0
-- zeromq=4.2.1=1
-- zlib=1.2.11=0
+  - bleach=2.0.0=py36_0
+  - ca-certificates=2017.11.5=0
+  - certifi=2017.11.5=py36_0
+  - decorator=4.1.2=py36_0
+  - entrypoints=0.2.3=py36_1
+  - gmp=6.1.2=0
+  - html5lib=1.0.1=py_0
+  - ipykernel=4.7.0=py36_0
+  - ipython=6.2.1=py36_1
+  - ipython_genutils=0.2.0=py36_0
+  - ipywidgets=6.0.1=py36_0
+  - jedi=0.11.1=py36_0
+  - jinja2=2.10=py36_0
+  - jsonschema=2.6.0=py36_0
+  - jupyter_client=5.2.2=py36_0
+  - jupyter_core=4.4.0=py_0
+  - jupyterlab=0.30.6=py36_0
+  - jupyterlab_launcher=0.6.0=py36_0
+  - libsodium=1.0.15=1
+  - markupsafe=1.0=py36_0
+  - mistune=0.8.3=py_0
+  - nbconvert=5.3.1=py_1
+  - nbformat=4.4.0=py36_0
+  - ncurses=5.9=10
+  - notebook=5.2.2=py36_1
+  - openssl=1.0.2n=0
+  - pandoc=2.1.1=0
+  - pandocfilters=1.4.1=py36_0
+  - parso=0.1.1=py_0
+  - pexpect=4.3.1=py36_0
+  - pickleshare=0.7.4=py36_0
+  - pip=9.0.1=py36_1
+  - prompt_toolkit=1.0.15=py36_0
+  - ptyprocess=0.5.2=py36_0
+  - pygments=2.2.0=py36_0
+  - python=3.6.4=0
+  - python-dateutil=2.6.1=py36_0
+  - pyzmq=16.0.2=py36_3
+  - readline=7.0=0
+  - setuptools=38.4.0=py36_0
+  - simplegeneric=0.8.1=py36_0
+  - six=1.11.0=py36_1
+  - sqlite=3.20.1=2
+  - terminado=0.8.1=py36_0
+  - testpath=0.3.1=py36_0
+  - tk=8.6.7=0
+  - tornado=4.5.3=py36_0
+  - traitlets=4.3.2=py36_0
+  - wcwidth=0.1.7=py36_0
+  - webencodings=0.5=py36_0
+  - wheel=0.30.0=py36_2
+  - widgetsnbextension=2.0.1=py36_0
+  - xz=5.2.3=0
+  - zeromq=4.2.1=1
+  - zlib=1.2.11=0
+  - pip:
+    - nteract-on-jupyter==1.3.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,50 +1,52 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-11 02:55:46 UTC
+# Frozen on 2018-02-01 12:25:55 UTC
 name: r2d
 channels:
-- conda-forge
-- defaults
-- conda-forge/label/broken
+  - conda-forge
+  - defaults
+  - conda-forge/label/broken
 dependencies:
-- backports=1.0=py27_1
-- backports.shutil_get_terminal_size=1.0.0=py_3
-- backports_abc=0.5=py27_0
-- ca-certificates=2017.11.5=0
-- certifi=2017.11.5=py27_0
-- decorator=4.1.2=py27_0
-- enum34=1.1.6=py27_1
-- ipykernel=4.7.0=py27_0
-- ipython=5.5.0=py27_0
-- ipython_genutils=0.2.0=py27_0
-- jupyter_client=5.2.1=py27_0
-- jupyter_core=4.4.0=py_0
-- libsodium=1.0.15=1
-- ncurses=5.9=10
-- openssl=1.0.2n=0
-- pathlib2=2.3.0=py27_0
-- pexpect=4.3.1=py27_0
-- pickleshare=0.7.4=py27_0
-- pip=9.0.1=py27_1
-- prompt_toolkit=1.0.15=py27_0
-- ptyprocess=0.5.2=py27_0
-- pygments=2.2.0=py27_0
-- python=2.7.14=4
-- python-dateutil=2.6.1=py27_0
-- pyzmq=16.0.2=py27_3
-- readline=7.0=0
-- scandir=1.6=py27_0
-- setuptools=38.4.0=py27_0
-- simplegeneric=0.8.1=py27_0
-- singledispatch=3.4.0.3=py27_0
-- six=1.11.0=py27_1
-- sqlite=3.20.1=2
-- ssl_match_hostname=3.5.0.1=py27_1
-- tk=8.6.7=0
-- tornado=4.5.3=py27_0
-- traitlets=4.3.2=py27_0
-- wcwidth=0.1.7=py27_0
-- wheel=0.30.0=py27_2
-- zeromq=4.2.1=1
-- zlib=1.2.11=0
+  - backports=1.0=py27_1
+  - backports.shutil_get_terminal_size=1.0.0=py_3
+  - backports_abc=0.5=py27_0
+  - ca-certificates=2017.11.5=0
+  - certifi=2017.11.5=py27_0
+  - decorator=4.1.2=py27_0
+  - enum34=1.1.6=py27_1
+  - ipykernel=4.7.0=py27_0
+  - ipython=5.5.0=py27_0
+  - ipython_genutils=0.2.0=py27_0
+  - jupyter_client=5.2.2=py27_0
+  - jupyter_core=4.4.0=py_0
+  - libsodium=1.0.15=1
+  - ncurses=5.9=10
+  - openssl=1.0.2n=0
+  - pathlib2=2.3.0=py27_0
+  - pexpect=4.3.1=py27_0
+  - pickleshare=0.7.4=py27_0
+  - pip=9.0.1=py27_1
+  - prompt_toolkit=1.0.15=py27_0
+  - ptyprocess=0.5.2=py27_0
+  - pygments=2.2.0=py27_0
+  - python=2.7.14=4
+  - python-dateutil=2.6.1=py27_0
+  - pyzmq=16.0.2=py27_3
+  - readline=7.0=0
+  - scandir=1.6=py27_0
+  - setuptools=38.4.0=py27_0
+  - simplegeneric=0.8.1=py27_0
+  - singledispatch=3.4.0.3=py27_0
+  - six=1.11.0=py27_1
+  - sqlite=3.20.1=2
+  - ssl_match_hostname=3.5.0.1=py27_1
+  - tk=8.6.7=0
+  - tornado=4.5.3=py27_0
+  - traitlets=4.3.2=py27_0
+  - wcwidth=0.1.7=py27_0
+  - wheel=0.30.0=py27_2
+  - zeromq=4.2.1=1
+  - zlib=1.2.11=0
+  - pip:
+    - backports.ssl-match-hostname==3.5.0.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,64 +1,67 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-11 02:57:06 UTC
+# Frozen on 2018-02-01 13:12:46 UTC
 name: r2d
 channels:
-- conda-forge
-- defaults
-- conda-forge/label/broken
+  - conda-forge
+  - defaults
+  - conda-forge/label/broken
 dependencies:
-- bleach=2.0.0=py35_0
-- ca-certificates=2017.11.5=0
-- certifi=2017.11.5=py35_0
-- decorator=4.1.2=py35_0
-- entrypoints=0.2.3=py35_1
-- gmp=6.1.2=0
-- html5lib=1.0.1=py_0
-- ipykernel=4.7.0=py35_0
-- ipython=6.2.1=py35_1
-- ipython_genutils=0.2.0=py35_0
-- ipywidgets=6.0.1=py35_0
-- jedi=0.10.2=py35_0
-- jinja2=2.10=py35_0
-- jsonschema=2.6.0=py35_0
-- jupyter_client=5.2.1=py35_0
-- jupyter_core=4.4.0=py_0
-- jupyterlab=0.30.6=py35_0
-- jupyterlab_launcher=0.6.0=py35_0
-- libsodium=1.0.15=1
-- markupsafe=1.0=py35_0
-- mistune=0.8.3=py_0
-- nbconvert=5.3.1=py_1
-- nbformat=4.4.0=py35_0
-- ncurses=5.9=10
-- notebook=5.2.2=py35_1
-- openssl=1.0.2n=0
-- pandoc=2.1=0
-- pandocfilters=1.4.1=py35_0
-- pexpect=4.3.1=py35_0
-- pickleshare=0.7.4=py35_0
-- pip=9.0.1=py35_1
-- prompt_toolkit=1.0.15=py35_0
-- ptyprocess=0.5.2=py35_0
-- pygments=2.2.0=py35_0
-- python=3.5.4=3
-- python-dateutil=2.6.1=py35_0
-- pyzmq=16.0.2=py35_3
-- readline=7.0=0
-- setuptools=38.4.0=py35_0
-- simplegeneric=0.8.1=py35_0
-- six=1.11.0=py35_1
-- sqlite=3.20.1=2
-- terminado=0.8.1=py35_0
-- testpath=0.3.1=py35_0
-- tk=8.6.7=0
-- tornado=4.5.3=py35_0
-- traitlets=4.3.2=py35_0
-- wcwidth=0.1.7=py35_0
-- webencodings=0.5=py35_0
-- wheel=0.30.0=py35_2
-- widgetsnbextension=2.0.1=py35_0
-- xz=5.2.3=0
-- zeromq=4.2.1=1
-- zlib=1.2.11=0
+  - bleach=2.0.0=py35_0
+  - ca-certificates=2017.11.5=0
+  - certifi=2017.11.5=py35_0
+  - decorator=4.1.2=py35_0
+  - entrypoints=0.2.3=py35_1
+  - gmp=6.1.2=0
+  - html5lib=1.0.1=py_0
+  - ipykernel=4.7.0=py35_0
+  - ipython=6.2.1=py35_1
+  - ipython_genutils=0.2.0=py35_0
+  - ipywidgets=6.0.1=py35_0
+  - jedi=0.11.1=py35_0
+  - jinja2=2.10=py35_0
+  - jsonschema=2.6.0=py35_0
+  - jupyter_client=5.2.2=py35_0
+  - jupyter_core=4.4.0=py_0
+  - jupyterlab=0.30.6=py35_0
+  - jupyterlab_launcher=0.6.0=py35_0
+  - libsodium=1.0.15=1
+  - markupsafe=1.0=py35_0
+  - mistune=0.8.3=py_0
+  - nbconvert=5.3.1=py_1
+  - nbformat=4.4.0=py35_0
+  - ncurses=5.9=10
+  - notebook=5.2.2=py35_1
+  - openssl=1.0.2n=0
+  - pandoc=2.1.1=0
+  - pandocfilters=1.4.1=py35_0
+  - parso=0.1.1=py_0
+  - pexpect=4.3.1=py35_0
+  - pickleshare=0.7.4=py35_0
+  - pip=9.0.1=py35_1
+  - prompt_toolkit=1.0.15=py35_0
+  - ptyprocess=0.5.2=py35_0
+  - pygments=2.2.0=py35_0
+  - python=3.5.4=3
+  - python-dateutil=2.6.1=py35_0
+  - pyzmq=16.0.2=py35_3
+  - readline=7.0=0
+  - setuptools=38.4.0=py35_0
+  - simplegeneric=0.8.1=py35_0
+  - six=1.11.0=py35_1
+  - sqlite=3.20.1=2
+  - terminado=0.8.1=py35_0
+  - testpath=0.3.1=py35_0
+  - tk=8.6.7=0
+  - tornado=4.5.3=py35_0
+  - traitlets=4.3.2=py35_0
+  - wcwidth=0.1.7=py35_0
+  - webencodings=0.5=py35_0
+  - wheel=0.30.0=py35_2
+  - widgetsnbextension=2.0.1=py35_0
+  - xz=5.2.3=0
+  - zeromq=4.2.1=1
+  - zlib=1.2.11=0
+  - pip:
+    - nteract-on-jupyter==1.3.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,64 +1,67 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-01-11 02:59:03 UTC
+# Frozen on 2018-02-01 12:30:02 UTC
 name: r2d
 channels:
-- conda-forge
-- defaults
-- conda-forge/label/broken
+  - conda-forge
+  - defaults
+  - conda-forge/label/broken
 dependencies:
-- bleach=2.0.0=py36_0
-- ca-certificates=2017.11.5=0
-- certifi=2017.11.5=py36_0
-- decorator=4.1.2=py36_0
-- entrypoints=0.2.3=py36_1
-- gmp=6.1.2=0
-- html5lib=1.0.1=py_0
-- ipykernel=4.7.0=py36_0
-- ipython=6.2.1=py36_1
-- ipython_genutils=0.2.0=py36_0
-- ipywidgets=6.0.1=py36_0
-- jedi=0.10.2=py36_0
-- jinja2=2.10=py36_0
-- jsonschema=2.6.0=py36_0
-- jupyter_client=5.2.1=py36_0
-- jupyter_core=4.4.0=py_0
-- jupyterlab=0.30.6=py36_0
-- jupyterlab_launcher=0.6.0=py36_0
-- libsodium=1.0.15=1
-- markupsafe=1.0=py36_0
-- mistune=0.8.3=py_0
-- nbconvert=5.3.1=py_1
-- nbformat=4.4.0=py36_0
-- ncurses=5.9=10
-- notebook=5.2.2=py36_1
-- openssl=1.0.2n=0
-- pandoc=2.1=0
-- pandocfilters=1.4.1=py36_0
-- pexpect=4.3.1=py36_0
-- pickleshare=0.7.4=py36_0
-- pip=9.0.1=py36_1
-- prompt_toolkit=1.0.15=py36_0
-- ptyprocess=0.5.2=py36_0
-- pygments=2.2.0=py36_0
-- python=3.6.4=0
-- python-dateutil=2.6.1=py36_0
-- pyzmq=16.0.2=py36_3
-- readline=7.0=0
-- setuptools=38.4.0=py36_0
-- simplegeneric=0.8.1=py36_0
-- six=1.11.0=py36_1
-- sqlite=3.20.1=2
-- terminado=0.8.1=py36_0
-- testpath=0.3.1=py36_0
-- tk=8.6.7=0
-- tornado=4.5.3=py36_0
-- traitlets=4.3.2=py36_0
-- wcwidth=0.1.7=py36_0
-- webencodings=0.5=py36_0
-- wheel=0.30.0=py36_2
-- widgetsnbextension=2.0.1=py36_0
-- xz=5.2.3=0
-- zeromq=4.2.1=1
-- zlib=1.2.11=0
+  - bleach=2.0.0=py36_0
+  - ca-certificates=2017.11.5=0
+  - certifi=2017.11.5=py36_0
+  - decorator=4.1.2=py36_0
+  - entrypoints=0.2.3=py36_1
+  - gmp=6.1.2=0
+  - html5lib=1.0.1=py_0
+  - ipykernel=4.7.0=py36_0
+  - ipython=6.2.1=py36_1
+  - ipython_genutils=0.2.0=py36_0
+  - ipywidgets=6.0.1=py36_0
+  - jedi=0.11.1=py36_0
+  - jinja2=2.10=py36_0
+  - jsonschema=2.6.0=py36_0
+  - jupyter_client=5.2.2=py36_0
+  - jupyter_core=4.4.0=py_0
+  - jupyterlab=0.30.6=py36_0
+  - jupyterlab_launcher=0.6.0=py36_0
+  - libsodium=1.0.15=1
+  - markupsafe=1.0=py36_0
+  - mistune=0.8.3=py_0
+  - nbconvert=5.3.1=py_1
+  - nbformat=4.4.0=py36_0
+  - ncurses=5.9=10
+  - notebook=5.2.2=py36_1
+  - openssl=1.0.2n=0
+  - pandoc=2.1.1=0
+  - pandocfilters=1.4.1=py36_0
+  - parso=0.1.1=py_0
+  - pexpect=4.3.1=py36_0
+  - pickleshare=0.7.4=py36_0
+  - pip=9.0.1=py36_1
+  - prompt_toolkit=1.0.15=py36_0
+  - ptyprocess=0.5.2=py36_0
+  - pygments=2.2.0=py36_0
+  - python=3.6.4=0
+  - python-dateutil=2.6.1=py36_0
+  - pyzmq=16.0.2=py36_3
+  - readline=7.0=0
+  - setuptools=38.4.0=py36_0
+  - simplegeneric=0.8.1=py36_0
+  - six=1.11.0=py36_1
+  - sqlite=3.20.1=2
+  - terminado=0.8.1=py36_0
+  - testpath=0.3.1=py36_0
+  - tk=8.6.7=0
+  - tornado=4.5.3=py36_0
+  - traitlets=4.3.2=py36_0
+  - wcwidth=0.1.7=py36_0
+  - webencodings=0.5=py36_0
+  - wheel=0.30.0=py36_2
+  - widgetsnbextension=2.0.1=py36_0
+  - xz=5.2.3=0
+  - zeromq=4.2.1=1
+  - zlib=1.2.11=0
+  - pip:
+    - nteract-on-jupyter==1.3.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,5 +1,7 @@
 dependencies:
-  - python==3.6.*
+  - python=3.6.*
   - ipywidgets==6.0.1
   - jupyterlab==0.30.6
   - notebook==5.2.2
+  - pip:
+    - nteract_on_jupyter==1.3.1

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -15,6 +15,8 @@ from ruamel.yaml import YAML
 
 
 MINICONDA_VERSION = '4.3.27'
+# need conda ≥ 4.4 to avoid bug adding spurious pip dependencies
+CONDA_VERSION = '4.4.8'
 
 HERE = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 
@@ -25,34 +27,6 @@ ENV_FILE_T = 'environment.py-{py}.yml'
 FROZEN_FILE_T = os.path.splitext(ENV_FILE_T)[0] + '.frozen.yml'
 
 yaml = YAML(typ='rt')
-
-
-def fixup(frozen_file):
-    """Fixup a frozen environment file
-
-    Conda export has a bug!
-    https://github.com/conda/conda/pull/6391
-    """
-    with open(frozen_file) as f:
-        env = yaml.load(f)
-
-    # scrub spurious pip dependencies
-    # due to conda #6391
-
-    # note: this scrubs *all* pip dependencies,
-    # so be more careful if we ever *want* conda to call
-    # out to pip.
-    pip_found = False
-    for idx, dep in enumerate(env['dependencies']):
-        if isinstance(dep, dict) and 'pip' in dep:
-            pip_found = True
-            break
-
-    if pip_found:
-        env['dependencies'].pop(idx)
-
-    with open(frozen_file, 'w') as f:
-        yaml.dump(env, f)
 
 
 def freeze(env_file, frozen_file):
@@ -79,6 +53,7 @@ def freeze(env_file, frozen_file):
         f"continuumio/miniconda3:{MINICONDA_VERSION}",
         "sh", "-c",
         '; '.join([
+            f"conda install -yq conda={CONDA_VERSION}",
             'conda config --add channels conda-forge',
             'conda config --system --set auto_update_conda false',
             f"conda env create -v -f /r2d/{env_file} -n r2d",
@@ -88,7 +63,6 @@ def freeze(env_file, frozen_file):
             f"conda env export -n r2d >> /r2d/{frozen_file}",
         ])
     ])
-    fixup(HERE / frozen_file)
 
 
 def set_python(py_env_file, py):

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -3,6 +3,10 @@
 Freeze the conda environment.yml
 
 Run in a continuumio/miniconda3 image to ensure portability
+
+Usage:
+
+python freeze.py [3.5]
 """
 
 from datetime import datetime
@@ -10,6 +14,7 @@ import os
 import pathlib
 import shutil
 from subprocess import check_call
+import sys
 
 from ruamel.yaml import YAML
 
@@ -39,6 +44,7 @@ def freeze(env_file, frozen_file):
 
     Result will be stored in frozen_file
     """
+    print(f"Freezing {env_file} -> {frozen_file}")
 
     with open(HERE / frozen_file, 'w') as f:
         f.write(f"# AUTO GENERATED FROM {env_file}, DO NOT MANUALLY MODIFY\n")
@@ -73,6 +79,8 @@ def set_python(py_env_file, py):
             text = f.read()
             if text and 'GENERATED' not in text:
                 return
+
+    print(f"Regenerating {py_env_file} from {ENV_FILE}")
     with open(ENV_FILE) as f:
         env = yaml.load(f)
     for idx, dep in enumerate(env['dependencies']):
@@ -89,7 +97,9 @@ def set_python(py_env_file, py):
 
 
 if __name__ == '__main__':
-    for py in ('2.7', '3.5', '3.6'):
+    # allow specifying which Pythons to update on argv
+    pys = sys.argv[1:] or ('2.7', '3.5', '3.6')
+    for py in pys:
         env_file = ENV_FILE_T.format(py=py)
         set_python(env_file, py)
         frozen_file = os.path.splitext(env_file)[0] + '.frozen.yml'

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -30,6 +30,9 @@ ${CONDA_DIR}/bin/conda config --system --set auto_update_conda false
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true
 
+# disable pip cache for conda-triggered pip installs
+export PIP_CACHE_DIR=0
+
 ${CONDA_DIR}/bin/conda env update -n root -f /tmp/environment.yml
 # enable nteract-on-jupyter, which was installed with pip
 jupyter serverextension enable nteract_on_jupyter --sys-prefix

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -20,31 +20,43 @@ if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
 fi
 
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+export PATH="${CONDA_DIR}/bin:$PATH"
 
 # Allow easy direct installs from conda forge
-${CONDA_DIR}/bin/conda config --system --add channels conda-forge
+conda config --system --add channels conda-forge
 
 # Do not attempt to auto update conda or dependencies
-${CONDA_DIR}/bin/conda config --system --set auto_update_conda false
+conda config --system --set auto_update_conda false
+conda config --system --set show_channel_urls true
+
+# switch Python in its own step
+# since switching Python during an env update can
+# prevent pip installation.
+# we wouldn't have this issue if we did `conda env create`
+# instead of `conda env update` in these cases
+conda install -y $(cat /tmp/environment.yml | grep -o '\spython=.*')
+
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
-${CONDA_DIR}/bin/conda config --system --set show_channel_urls true
 
-# disable pip cache for conda-triggered pip installs
-export PIP_CACHE_DIR=0
+echo "installing root env:"
+cat /tmp/environment.yml
+conda env update -n root -f /tmp/environment.yml
 
-${CONDA_DIR}/bin/conda env update -n root -f /tmp/environment.yml
 # enable nteract-on-jupyter, which was installed with pip
 jupyter serverextension enable nteract_on_jupyter --sys-prefix
 
 if [[ -f /tmp/kernel-environment.yml ]]; then
     # install kernel env and register kernelspec
-    ${CONDA_DIR}/bin/conda env create -n kernel -f /tmp/kernel-environment.yml
+    echo "installing kernel env:"
+    cat /tmp/kernel-environment.yml
+
+    conda env create -n kernel -f /tmp/kernel-environment.yml
     ${CONDA_DIR}/envs/kernel/bin/ipython kernel install --prefix "${CONDA_DIR}"
 fi
 
 # Clean things out!
-${CONDA_DIR}/bin/conda clean -tipsy
+conda clean -tipsy
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -31,6 +31,8 @@ echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 ${CONDA_DIR}/bin/conda config --system --set show_channel_urls true
 
 ${CONDA_DIR}/bin/conda env update -n root -f /tmp/environment.yml
+# enable nteract-on-jupyter, which was installed with pip
+jupyter serverextension enable nteract_on_jupyter --sys-prefix
 
 if [[ -f /tmp/kernel-environment.yml ]]; then
     # install kernel env and register kernelspec


### PR DESCRIPTION
via pip

Removes workaround for conda env export bug by updating conda to 4.4 in the freeze container.

equivalent of #200 for conda