### PR TITLE
Fix Python version detection for conda

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -100,7 +100,7 @@ class CondaBuildPack(BuildPack):
                     self._python_version = self.major_pythons.get(py_version[0])
                 else:
                     # return major.minor
-                    self._python_version = '.'.join(py_version[:2])
+                    self._python_version = '.'.join(py_version.split('.')[:2])
             else:
                 self._python_version = ''
 

--- a/tests/conda/binder-dir/binder/environment.yml
+++ b/tests/conda/binder-dir/binder/environment.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - python=3.5
   - numpy

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sys
 
-assert sys.version_info[:2] == (3, 6), sys.version
+assert sys.version_info[:2] == (3, 5), sys.version
 
 import numpy


### PR DESCRIPTION
Minor parsing error identifying Python version caused Python 3.5 to be identified as Python 3 (and thus ends up using the default of 3.6).

Updates one of the conda tests to ensure that Python 3.5 is tested.