### PR TITLE
pin nteract_on_jupyter to 1.4.0

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,25 +1,25 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-01 12:30:02 UTC
+# Frozen on 2018-02-07 00:43:42 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - bleach=2.0.0=py36_0
+  - bleach=2.0.0=py_1
   - ca-certificates=2017.11.5=0
   - certifi=2017.11.5=py36_0
   - decorator=4.1.2=py36_0
   - entrypoints=0.2.3=py36_1
   - gmp=6.1.2=0
   - html5lib=1.0.1=py_0
-  - ipykernel=4.7.0=py36_0
+  - ipykernel=4.8.0=py36_0
   - ipython=6.2.1=py36_1
   - ipython_genutils=0.2.0=py36_0
   - ipywidgets=6.0.1=py36_0
   - jedi=0.11.1=py36_0
   - jinja2=2.10=py36_0
-  - jsonschema=2.6.0=py36_0
+  - jsonschema=2.6.0=py36_1
   - jupyter_client=5.2.2=py36_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.30.6=py36_0
@@ -62,6 +62,6 @@ dependencies:
   - zeromq=4.2.1=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.3.1
+    - nteract-on-jupyter==1.4.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-01 12:25:55 UTC
+# Frozen on 2018-02-07 00:39:50 UTC
 name: r2d
 channels:
   - conda-forge

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,25 +1,25 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-01 13:12:46 UTC
+# Frozen on 2018-02-07 00:41:32 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - bleach=2.0.0=py35_0
+  - bleach=2.0.0=py_1
   - ca-certificates=2017.11.5=0
   - certifi=2017.11.5=py35_0
   - decorator=4.1.2=py35_0
   - entrypoints=0.2.3=py35_1
   - gmp=6.1.2=0
   - html5lib=1.0.1=py_0
-  - ipykernel=4.7.0=py35_0
+  - ipykernel=4.8.0=py35_0
   - ipython=6.2.1=py35_1
   - ipython_genutils=0.2.0=py35_0
   - ipywidgets=6.0.1=py35_0
   - jedi=0.11.1=py35_0
   - jinja2=2.10=py35_0
-  - jsonschema=2.6.0=py35_0
+  - jsonschema=2.6.0=py35_1
   - jupyter_client=5.2.2=py35_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.30.6=py35_0
@@ -62,6 +62,6 @@ dependencies:
   - zeromq=4.2.1=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.3.1
+    - nteract-on-jupyter==1.4.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,25 +1,25 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-01 12:30:02 UTC
+# Frozen on 2018-02-07 00:43:42 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - bleach=2.0.0=py36_0
+  - bleach=2.0.0=py_1
   - ca-certificates=2017.11.5=0
   - certifi=2017.11.5=py36_0
   - decorator=4.1.2=py36_0
   - entrypoints=0.2.3=py36_1
   - gmp=6.1.2=0
   - html5lib=1.0.1=py_0
-  - ipykernel=4.7.0=py36_0
+  - ipykernel=4.8.0=py36_0
   - ipython=6.2.1=py36_1
   - ipython_genutils=0.2.0=py36_0
   - ipywidgets=6.0.1=py36_0
   - jedi=0.11.1=py36_0
   - jinja2=2.10=py36_0
-  - jsonschema=2.6.0=py36_0
+  - jsonschema=2.6.0=py36_1
   - jupyter_client=5.2.2=py36_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.30.6=py36_0
@@ -62,6 +62,6 @@ dependencies:
   - zeromq=4.2.1=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.3.1
+    - nteract-on-jupyter==1.4.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -4,4 +4,4 @@ dependencies:
   - jupyterlab==0.30.6
   - notebook==5.2.2
   - pip:
-    - nteract_on_jupyter==1.3.1
+    - nteract_on_jupyter==1.4.0

--- a/repo2docker/buildpacks/python/requirements.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements.txt, DO NOT MANUALLY MODIFY
-# Frozen on Wed Jan 31 21:54:41 UTC 2018
+# Frozen on Wed Feb  7 00:37:05 UTC 2018
 bleach==2.1.2
 decorator==4.2.1
 entrypoints==0.2.3
@@ -20,7 +20,7 @@ mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0
 notebook==5.2.2
-nteract-on-jupyter==1.3.1
+nteract-on-jupyter==1.4.0
 pandocfilters==1.4.2
 parso==0.1.1
 pexpect==4.3.1

--- a/repo2docker/buildpacks/python/requirements.txt
+++ b/repo2docker/buildpacks/python/requirements.txt
@@ -1,4 +1,4 @@
 notebook==5.2.2
 ipywidgets==6.0.1
 jupyterlab==0.30.6
-nteract_on_jupyter==1.3.1
+nteract_on_jupyter==1.4.0

--- a/repo2docker/buildpacks/python/requirements2.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements2.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements2.txt, DO NOT MANUALLY MODIFY
-# Frozen on Wed Jan 31 21:55:07 UTC 2018
+# Frozen on Wed Feb  7 00:37:58 UTC 2018
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 certifi==2018.1.18


### PR DESCRIPTION
This brings `nteract_on_jupyter` up to date. When I did this build I noticed it created these (untracked) files as well:

```
	repo2docker/buildpacks/conda/environment.py-3.5.yml
	repo2docker/buildpacks/conda/environment.py-3.6.yml
```

I don't need to add those do I?