### PR TITLE
Bump jupyterlab and jupyter notebook to latest versions

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-07 00:43:42 UTC
+# Frozen on 2018-02-08 08:10:01 UTC
 name: r2d
 channels:
   - conda-forge
@@ -22,15 +22,15 @@ dependencies:
   - jsonschema=2.6.0=py36_1
   - jupyter_client=5.2.2=py36_0
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.30.6=py36_0
-  - jupyterlab_launcher=0.6.0=py36_0
+  - jupyterlab=0.31.5=py36_1
+  - jupyterlab_launcher=0.10.3=py36_0
   - libsodium=1.0.15=1
   - markupsafe=1.0=py36_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py36_0
   - ncurses=5.9=10
-  - notebook=5.2.2=py36_1
+  - notebook=5.4.0=py36_0
   - openssl=1.0.2n=0
   - pandoc=2.1.1=0
   - pandocfilters=1.4.1=py36_0
@@ -45,6 +45,7 @@ dependencies:
   - python-dateutil=2.6.1=py36_0
   - pyzmq=16.0.2=py36_3
   - readline=7.0=0
+  - send2trash=1.4.2=py_0
   - setuptools=38.4.0=py36_0
   - simplegeneric=0.8.1=py36_0
   - six=1.11.0=py36_1

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-07 00:39:50 UTC
+# Frozen on 2018-02-08 08:02:45 UTC
 name: r2d
 channels:
   - conda-forge

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-07 00:41:32 UTC
+# Frozen on 2018-02-08 08:05:55 UTC
 name: r2d
 channels:
   - conda-forge
@@ -22,15 +22,15 @@ dependencies:
   - jsonschema=2.6.0=py35_1
   - jupyter_client=5.2.2=py35_0
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.30.6=py35_0
-  - jupyterlab_launcher=0.6.0=py35_0
+  - jupyterlab=0.31.5=py35_1
+  - jupyterlab_launcher=0.10.3=py35_0
   - libsodium=1.0.15=1
   - markupsafe=1.0=py35_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py35_0
   - ncurses=5.9=10
-  - notebook=5.2.2=py35_1
+  - notebook=5.4.0=py35_0
   - openssl=1.0.2n=0
   - pandoc=2.1.1=0
   - pandocfilters=1.4.1=py35_0
@@ -45,6 +45,7 @@ dependencies:
   - python-dateutil=2.6.1=py35_0
   - pyzmq=16.0.2=py35_3
   - readline=7.0=0
+  - send2trash=1.4.2=py_0
   - setuptools=38.4.0=py35_0
   - simplegeneric=0.8.1=py35_0
   - six=1.11.0=py35_1

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-02-07 00:43:42 UTC
+# Frozen on 2018-02-08 08:10:01 UTC
 name: r2d
 channels:
   - conda-forge
@@ -22,15 +22,15 @@ dependencies:
   - jsonschema=2.6.0=py36_1
   - jupyter_client=5.2.2=py36_0
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.30.6=py36_0
-  - jupyterlab_launcher=0.6.0=py36_0
+  - jupyterlab=0.31.5=py36_1
+  - jupyterlab_launcher=0.10.3=py36_0
   - libsodium=1.0.15=1
   - markupsafe=1.0=py36_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py36_0
   - ncurses=5.9=10
-  - notebook=5.2.2=py36_1
+  - notebook=5.4.0=py36_0
   - openssl=1.0.2n=0
   - pandoc=2.1.1=0
   - pandocfilters=1.4.1=py36_0
@@ -45,6 +45,7 @@ dependencies:
   - python-dateutil=2.6.1=py36_0
   - pyzmq=16.0.2=py36_3
   - readline=7.0=0
+  - send2trash=1.4.2=py_0
   - setuptools=38.4.0=py36_0
   - simplegeneric=0.8.1=py36_0
   - six=1.11.0=py36_1

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
   - python=3.6.*
   - ipywidgets==6.0.1
-  - jupyterlab==0.30.6
-  - notebook==5.2.2
+  - jupyterlab==0.31.5
+  - notebook==5.4.0
   - pip:
     - nteract_on_jupyter==1.4.0

--- a/repo2docker/buildpacks/python/requirements.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements.txt, DO NOT MANUALLY MODIFY
-# Frozen on Wed Feb  7 00:37:05 UTC 2018
+# Frozen on Thu  8 Feb 2018 09:22:43 UTC
 bleach==2.1.2
 decorator==4.2.1
 entrypoints==0.2.3
@@ -13,13 +13,13 @@ Jinja2==2.10
 jsonschema==2.6.0
 jupyter-client==5.2.2
 jupyter-core==4.4.0
-jupyterlab-launcher==0.6.0
-jupyterlab==0.30.6
+jupyterlab-launcher==0.10.3
+jupyterlab==0.31.5
 MarkupSafe==1.0
 mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0
-notebook==5.2.2
+notebook==5.4.0
 nteract-on-jupyter==1.4.0
 pandocfilters==1.4.2
 parso==0.1.1
@@ -30,6 +30,7 @@ ptyprocess==0.5.2
 Pygments==2.2.0
 python-dateutil==2.6.1
 pyzmq==16.0.4
+Send2Trash==1.4.2
 simplegeneric==0.8.1
 six==1.11.0
 terminado==0.8.1

--- a/repo2docker/buildpacks/python/requirements.txt
+++ b/repo2docker/buildpacks/python/requirements.txt
@@ -1,4 +1,4 @@
-notebook==5.2.2
+notebook==5.4.0
 ipywidgets==6.0.1
-jupyterlab==0.30.6
+jupyterlab==0.31.5
 nteract_on_jupyter==1.4.0

--- a/repo2docker/buildpacks/python/requirements2.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements2.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements2.txt, DO NOT MANUALLY MODIFY
-# Frozen on Wed Feb  7 00:37:58 UTC 2018
+# Frozen on Thu  8 Feb 2018 09:23:20 UTC
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 certifi==2018.1.18


### PR DESCRIPTION
Upgrades us to jupyterlab 0.31.5 and notebook 5.4.0.