### PR TITLE
add appendix

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -112,6 +112,11 @@ USER ${NB_USER}
 RUN ./{{ s }}
 {% endfor %}
 {% endif -%}
+
+{% if appendix -%}
+# Appendix:
+{{ appendix }}
+{% endif %}
 """
 
 DOC_URL = "http://repo2docker.readthedocs.io/en/latest/samples.html"
@@ -136,6 +141,7 @@ class BuildPack:
 
     def __init__(self):
         self.log = logging.getLogger('repo2docker')
+        self.appendix = ''
 
     def get_packages(self):
         """
@@ -309,6 +315,7 @@ class BuildPack:
             build_script_files=self.get_build_script_files(),
             base_packages=sorted(self.get_base_packages()),
             post_build_scripts=self.get_post_build_scripts(),
+            appendix=self.appendix,
         )
 
     def build(self, image_spec, memory_limit, build_args):

--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -15,7 +15,7 @@ class DockerBuildPack(BuildPack):
     def render(self):
         Dockerfile = self.binder_path('Dockerfile')
         with open(Dockerfile) as f:
-            return f.read()
+            return '\n'.join([f.read(), self.appendix, ''])
 
     def build(self, image_spec, memory_limit, build_args):
         limits = {

--- a/repo2docker/buildpacks/legacy.py
+++ b/repo2docker/buildpacks/legacy.py
@@ -8,7 +8,7 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
 
     dockerfile = '._binder.Dockerfile'
 
-    dockerfile_appendix = dedent(r"""
+    legacy_appendix = dedent(r"""
     USER root
     COPY . /home/main/notebooks
     RUN chown -R main:main /home/main/notebooks
@@ -27,7 +27,7 @@ class LegacyBinderDockerBuildPack(DockerBuildPack):
 
     def render(self):
         with open('Dockerfile') as f:
-            return f.read() + self.dockerfile_appendix
+            return '\n'.join([f.read(), self.legacy_appendix, self.appendix, ''])
 
     def build(self, image_spec, memory_limit, build_args):
         with open(self.dockerfile, 'w') as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,11 @@ class LocalRepo(pytest.File):
     def collect(self):
         yield Repo2DockerTest(
             self.fspath.basename, self,
-            args=[self.fspath.dirname, './verify'],
+            args=[
+                '--appendix', 'RUN echo "appendix" > /tmp/appendix',
+                self.fspath.dirname,
+                './verify',
+            ],
         )
 
 

--- a/tests/venv/default/verify
+++ b/tests/venv/default/verify
@@ -2,5 +2,8 @@
 # Verify that the default just provides a py3 environment with jupyter
 import sys
 
-assert sys.version_info[:2] == (3, 6)
+assert sys.version_info[:2] == (3, 6), sys.version
 import jupyter
+
+with open('/tmp/appendix') as f:
+    assert f.read().strip() == 'appendix'


### PR DESCRIPTION
supports adding arbitrary build steps to the end of Dockerfile

this enables some discussed features like Binder-deployment-specific appendices to images (e.g. enabling the nbmelt extension to shutdown notebooks that don't get used after a shorter timeout than the existing 10 minute idle timeout).