### PR TITLE
Add shiny-server.

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -128,11 +128,17 @@ class RBuildPack(PythonBuildPack):
         # This is MD5, because that is what RStudio download page provides!
         rstudio_checksum = '24cd11f0405d8372b4168fc9956e0386'
 
+        shiny_url = 'https://download3.rstudio.org/ubuntu-12.04/x86_64/shiny-server-1.5.6.875-amd64.deb'
+        shiny_checksum = 'de039a6f9e055de693524e6cb44f6a03'
+
         # Version of MRAN to pull devtools from.
         devtools_version = '2018-02-01'
 
         # IRKernel version - specified as a tag in the IRKernel repository
         irkernel_version = '0.8.11'
+
+        nbrsessionproxy_pip_spec = 'nbrsessionproxy==0.6.1'
+        nbrsessionproxy_pip_spec = 'git+https://github.com/ryanlovett/nbrsessionproxy.git@432262c'
 
         return super().get_build_scripts() + [
             (
@@ -156,14 +162,28 @@ class RBuildPack(PythonBuildPack):
                 )
             ),
             (
+                "root",
+                # Install Shiny!
+                r"""
+                curl --silent --location --fail {url} > /tmp/{deb}.deb && \
+                echo '{checksum} /tmp/{deb}.deb' | md5sum -c - && \
+                dpkg -i /tmp/{deb}.deb && \
+                rm /tmp/{deb}.deb
+                """.format(
+                    url=shiny_url,
+                    checksum=shiny_checksum,
+                    deb="shiny"
+                )
+            ),
+            (
                 "${NB_USER}",
                 # Install nbrsessionproxy
                 r"""
-                pip install --no-cache-dir nbrsessionproxy==0.6.1 && \
+                pip install --no-cache-dir {pip_spec} && \
                 jupyter serverextension enable nbrsessionproxy --sys-prefix && \
                 jupyter nbextension install --py nbrsessionproxy --sys-prefix && \
                 jupyter nbextension enable --py nbrsessionproxy --sys-prefix
-                """
+                """.format(pip_spec=nbrsessionproxy_pip_spec)
             ),
             (
                 "${NB_USER}",
@@ -189,6 +209,11 @@ class RBuildPack(PythonBuildPack):
         mran_url = 'https://mran.microsoft.com/snapshot/{}'.format(
             self.checkpoint_date.isoformat()
         )
+
+        # - "ShinyApps" is a shiny quasi-convention; I prefer "shiny"
+        shiny_apps_dir = 'ShinyApps'
+        shiny_port = '3838'
+
         assemble_scripts = super().get_assemble_scripts() + [
             (
                 "root",
@@ -196,7 +221,36 @@ class RBuildPack(PythonBuildPack):
                 # We set download method to be curl so we get HTTPS support
                 r"""
                 echo "options(repos = c(CRAN='{mran_url}'), download.file.method = 'libcurl')" > /etc/R/Rprofile.site
+
                 """.format(mran_url=mran_url)
+            ),
+            (
+                "root",
+                # Even with the container env, without this shiny will want to
+                # use ~/R/x86...
+                r"""
+                sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
+                echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
+                """
+            ),
+            (
+                # Not all of these locations are configurable; log_dir is
+                "root",
+                r"""
+                install -o ${NB_USER} -g ${NB_USER} -d /var/log/shiny-server && \
+                install -o ${NB_USER} -g ${NB_USER} -d /var/lib/shiny-server && \
+                install -o ${NB_USER} -g ${NB_USER} /dev/null /var/log/shiny-server.log && \
+                install -o ${NB_USER} -g ${NB_USER} /dev/null /var/run/shiny-server.pid
+                """
+            ),
+            (
+                # mvp -- not optimal.
+                # - how does repo2docker want to COPY files
+                # - should shiny-server.conf be configurable by users?
+                "root",
+                r"""
+                printf "run_as ${{NB_USER}};\nserver {{\n  listen {port};\n  location / {{\n    site_dir ${{HOME}}/{apps_dir};\n    log_dir ${{HOME}}/logs;\n    directory_index on;\n  }}\n}}\n" > /etc/shiny-server/shiny-server.conf
+                """.format(apps_dir=shiny_apps_dir, port=shiny_port)
             ),
         ]
 


### PR DESCRIPTION
This assumes apps are in ~/ShinyApps/. For now this can be seeded by
postBuild, but a better convention is to specify remote app locations in
something like a shinyapps.txt file.