### PR TITLE
Do not require postBuild to be executable

### DIFF
--- a/tests/memlimit.py
+++ b/tests/memlimit.py
@@ -37,7 +37,7 @@ def does_build(builddir, mem_limit, mem_allocate_mb):
         except subprocess.CalledProcessError as e:
             output = e.output.decode()
             print(output)
-            if "The command '/bin/sh -c ./postBuild' returned a non-zero code: 137" in output:
+            if "/postBuild' returned a non-zero code: 137" in output:
                 return False
             else:
                 raise

--- a/tests/venv/postBuild/README.rst
+++ b/tests/venv/postBuild/README.rst
@@ -5,15 +5,3 @@ It is possible to run scripts after you've built the environment specified in
 your other files. This could be used to, for example, download data or run
 some configuration scripts. For example, this will download and install a
 Jupyter extension.
-
-.. note::
-
-   This file needs to be executable in order to work with ``repo2docker``. If
-   you're on Linux or macOS, run::
-
-       chmod +x postBuild
-
-   If you're on windows, you can accomplish the same behavior with this
-   ``git`` command::
-
-       git update-index --chmod=+x postBuild


### PR DESCRIPTION
This is hard for windows users and from the GitHub UI,
and provides dubious benefits. So let's remove the requirement!

Fixes #240