### PR TITLE
remove -v from conda env update

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -117,8 +117,9 @@ class CondaBuildPack(BaseImage):
             assembly_scripts.append((
                 '${NB_USER}',
                 r"""
-                conda env update -v -n {} -f "{}" && \
-                conda clean -tipsy
+                conda env update -n {0} -f "{1}" && \
+                conda clean -tipsy && \
+                conda list -n {0}
                 """.format(env_name, environment_yml)
             ))
         return super().get_assemble_scripts() + assembly_scripts


### PR DESCRIPTION
there is so much verbose output that it seems to make it even harder to see what's happening, except in very particular cases.

while it's useful for debugging purposes when things like post-link fail, I don't think we should do it by default.

added a `conda list` at the end to see what's been installed