### PR TITLE
omit appendix on custom Dockerfiles

### DIFF
--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -15,7 +15,7 @@ class DockerBuildPack(BuildPack):
     def render(self):
         Dockerfile = self.binder_path('Dockerfile')
         with open(Dockerfile) as f:
-            return '\n'.join([f.read(), self.appendix, ''])
+            return f.read()
 
     def build(self, image_spec, memory_limit, build_args):
         limits = {


### PR DESCRIPTION
using a custom Dockerfile means opting out of *all* repo2docker logic

prompted by discussion in https://github.com/jupyterhub/binderhub/pull/459