### PR TITLE
[MRG] Setup R libraries path for RStudio

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -156,6 +156,16 @@ class RBuildPack(PythonBuildPack):
                 )
             ),
             (
+                "root",
+                # Set paths so that RStudio shares libraries with base R
+                # install. This first comments out any R_LIBS_USER that
+                # might be set in /etc/R/Renviron and then sets it.
+                r"""
+                sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
+                echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
+                """
+            ),
+            (
                 "${NB_USER}",
                 # Install nbrsessionproxy
                 r"""


### PR DESCRIPTION
Fixes #237 

This makes sure our base R install (used by the notebook kernel) and
RStudio share the same packages.

Any ideas how we could test that this worked? I would copy the existing R test but don't know how to run the `verify` command in RStudio.