### PR TITLE
make sure there's a newline before each 'File: ' heading

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -202,7 +202,7 @@ for root, _, files in os.walk(os.path.join('..', '..', 'tests')):
         continue
     header = files.pop(files.index('README.rst'))
     with open(os.path.join(root, header), 'r') as ff:
-        this_s = ff.read() + '\n'
+        this_s = ff.read() + '\n\n'
         title = this_s.split('\n')[0]
     for ifile in files:
         filename = os.path.basename(ifile)


### PR DESCRIPTION
Currently, the file `tests/venv/postBuild/README.rst` is missing a newline at the end of the last line, and so [samples.html](https://repo2docker.readthedocs.io/en/latest/samples.html) in the generated docs fails to properly format the `File: postBuild` heading. This fixes the code in `docs/source/conf.py` to add an extra newline Just In Case.
