### PR TITLE
Adding unzip to base packages

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -170,6 +170,8 @@ class BuildPack:
             # FIXME: Use npm from nodesource!
             # Everything seems to depend on npm these days, unfortunately.
             "npm",
+            
+            "unzip",
         }
 
     def get_env(self):


### PR DESCRIPTION
adding unzip to base packages so you can just run unzip on the terminal (closing https://github.com/jupyter/repo2docker/issues/251)