### PR TITLE
Fix detecting dependency files in binder/ subidr

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -1,7 +1,6 @@
 """
 Buildpack for conda environments
 """
-import glob
 import os
 import re
 
@@ -123,7 +122,6 @@ class CondaBuildPack(BaseImage):
                 """.format(env_name, environment_yml)
             ))
         return super().get_assemble_scripts() + assembly_scripts
-
 
     def detect(self):
         return os.path.exists(self.binder_path('environment.yml')) and super().detect()

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -85,7 +85,8 @@ class PythonBuildPack(BaseImage):
         return assemble_scripts
 
     def detect(self):
-        return os.path.exists('requirements.txt') and super().detect()
+        return (os.path.exists(self.binder_path('requirements.txt')) and
+                super().detect())
 
 
 class Python2BuildPack(PythonBuildPack):
@@ -95,7 +96,6 @@ class Python2BuildPack(PythonBuildPack):
             'python-dev',
             'virtualenv'
         })
-
 
     def get_env(self):
         return super().get_env() + [

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -210,11 +210,12 @@ class RBuildPack(PythonBuildPack):
             ),
         ]
 
-        if os.path.exists('install.R'):
+        installR_path = self.binder_path('install.R')
+        if os.path.exists(installR_path):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    "Rscript install.R"
+                    "Rscript %s" % installR_path
                 )
             ]
 


### PR DESCRIPTION
This PR aims to replace all "raw" file path accesses with calls to `binder_path(path)` which checks if the file exists in the `binder/` subdirectory.