### PR TITLE
Use travis_retry to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   # cd into tests so CWD being repo2docker does not hide
   # possible issues with MANIFEST.in
-  - cd tests && pytest --cov repo2docker -v ${REPO_TYPE}
+  - cd tests && travis_retry pytest --cov repo2docker -v ${REPO_TYPE}
 after_success:
   - pip install codecov
   - codecov


### PR DESCRIPTION
Enables travis retry to reduce number of times we need to manually restart tests. It feels like most of the test failures that need restarting are related to network issues.