### PR TITLE
update nteract_on_jupyter to 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ include/
 # Docs
 generated/
 test_file_text.txt
+
+# Untracked artifacts from the conda script
+repo2docker/buildpacks/conda/environment.py-3.5.yml
+repo2docker/buildpacks/conda/environment.py-3.6.yml

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-03-20 00:47:27 UTC
+# Frozen on 2018-04-02 07:27:43 UTC
 name: r2d
 channels:
   - conda-forge
@@ -24,7 +24,7 @@ dependencies:
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.31.5=py36_1
   - jupyterlab_launcher=0.10.5=py36_0
-  - libsodium=1.0.15=1
+  - libsodium=1.0.16=0
   - markupsafe=1.0=py36_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
@@ -37,13 +37,13 @@ dependencies:
   - parso=0.1.1=py_0
   - pexpect=4.4.0=py36_0
   - pickleshare=0.7.4=py36_0
-  - pip=9.0.2=py36_0
+  - pip=9.0.3=py36_0
   - prompt_toolkit=1.0.15=py36_0
   - ptyprocess=0.5.2=py36_0
   - pygments=2.2.0=py36_0
-  - python=3.6.4=0
-  - python-dateutil=2.7.0=py_0
-  - pyzmq=17.0.0=py36_3
+  - python=3.6.5=0
+  - python-dateutil=2.7.2=py_0
+  - pyzmq=17.0.0=py36_4
   - readline=7.0=0
   - send2trash=1.5.0=py_0
   - setuptools=39.0.1=py36_0
@@ -58,11 +58,11 @@ dependencies:
   - wcwidth=0.1.7=py36_0
   - webencodings=0.5=py36_0
   - wheel=0.30.0=py36_2
-  - widgetsnbextension=3.1.4=py36_0
+  - widgetsnbextension=3.2.0=py36_0
   - xz=5.2.3=0
-  - zeromq=4.2.3=2
+  - zeromq=4.2.5=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.5.0
+    - nteract-on-jupyter==1.6.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-03-20 00:42:45 UTC
+# Frozen on 2018-04-02 07:21:15 UTC
 name: r2d
 channels:
   - conda-forge
@@ -18,19 +18,19 @@ dependencies:
   - ipython_genutils=0.2.0=py27_0
   - jupyter_client=5.2.3=py27_0
   - jupyter_core=4.4.0=py_0
-  - libsodium=1.0.15=1
+  - libsodium=1.0.16=0
   - ncurses=5.9=10
   - openssl=1.0.2n=0
   - pathlib2=2.3.0=py27_0
   - pexpect=4.4.0=py27_0
   - pickleshare=0.7.4=py27_0
-  - pip=9.0.2=py27_0
+  - pip=9.0.3=py27_0
   - prompt_toolkit=1.0.15=py27_0
   - ptyprocess=0.5.2=py27_0
   - pygments=2.2.0=py27_0
-  - python=2.7.14=4
-  - python-dateutil=2.7.0=py_0
-  - pyzmq=17.0.0=py27_3
+  - python=2.7.14=5
+  - python-dateutil=2.7.2=py_0
+  - pyzmq=17.0.0=py27_4
   - readline=7.0=0
   - scandir=1.7=py27_0
   - setuptools=39.0.1=py27_0
@@ -44,7 +44,7 @@ dependencies:
   - traitlets=4.3.2=py27_0
   - wcwidth=0.1.7=py27_0
   - wheel=0.30.0=py27_2
-  - zeromq=4.2.3=2
+  - zeromq=4.2.5=1
   - zlib=1.2.11=0
   - pip:
     - backports.ssl-match-hostname==3.5.0.1

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-03-20 00:43:53 UTC
+# Frozen on 2018-04-02 07:23:18 UTC
 name: r2d
 channels:
   - conda-forge
@@ -24,7 +24,7 @@ dependencies:
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.31.5=py35_1
   - jupyterlab_launcher=0.10.5=py35_0
-  - libsodium=1.0.15=1
+  - libsodium=1.0.16=0
   - markupsafe=1.0=py35_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
@@ -37,13 +37,13 @@ dependencies:
   - parso=0.1.1=py_0
   - pexpect=4.4.0=py35_0
   - pickleshare=0.7.4=py35_0
-  - pip=9.0.2=py35_0
+  - pip=9.0.3=py35_0
   - prompt_toolkit=1.0.15=py35_0
   - ptyprocess=0.5.2=py35_0
   - pygments=2.2.0=py35_0
   - python=3.5.5=0
-  - python-dateutil=2.7.0=py_0
-  - pyzmq=17.0.0=py35_3
+  - python-dateutil=2.7.2=py_0
+  - pyzmq=17.0.0=py35_4
   - readline=7.0=0
   - send2trash=1.5.0=py_0
   - setuptools=39.0.1=py35_0
@@ -58,11 +58,11 @@ dependencies:
   - wcwidth=0.1.7=py35_0
   - webencodings=0.5=py35_0
   - wheel=0.30.0=py35_2
-  - widgetsnbextension=3.1.4=py35_0
+  - widgetsnbextension=3.2.0=py35_0
   - xz=5.2.3=0
-  - zeromq=4.2.3=2
+  - zeromq=4.2.5=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.5.0
+    - nteract-on-jupyter==1.6.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-03-20 00:47:27 UTC
+# Frozen on 2018-04-02 07:27:43 UTC
 name: r2d
 channels:
   - conda-forge
@@ -24,7 +24,7 @@ dependencies:
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.31.5=py36_1
   - jupyterlab_launcher=0.10.5=py36_0
-  - libsodium=1.0.15=1
+  - libsodium=1.0.16=0
   - markupsafe=1.0=py36_0
   - mistune=0.8.3=py_0
   - nbconvert=5.3.1=py_1
@@ -37,13 +37,13 @@ dependencies:
   - parso=0.1.1=py_0
   - pexpect=4.4.0=py36_0
   - pickleshare=0.7.4=py36_0
-  - pip=9.0.2=py36_0
+  - pip=9.0.3=py36_0
   - prompt_toolkit=1.0.15=py36_0
   - ptyprocess=0.5.2=py36_0
   - pygments=2.2.0=py36_0
-  - python=3.6.4=0
-  - python-dateutil=2.7.0=py_0
-  - pyzmq=17.0.0=py36_3
+  - python=3.6.5=0
+  - python-dateutil=2.7.2=py_0
+  - pyzmq=17.0.0=py36_4
   - readline=7.0=0
   - send2trash=1.5.0=py_0
   - setuptools=39.0.1=py36_0
@@ -58,11 +58,11 @@ dependencies:
   - wcwidth=0.1.7=py36_0
   - webencodings=0.5=py36_0
   - wheel=0.30.0=py36_2
-  - widgetsnbextension=3.1.4=py36_0
+  - widgetsnbextension=3.2.0=py36_0
   - xz=5.2.3=0
-  - zeromq=4.2.3=2
+  - zeromq=4.2.5=1
   - zlib=1.2.11=0
   - pip:
-    - nteract-on-jupyter==1.5.0
+    - nteract-on-jupyter==1.6.0
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - tornado==4.5.3
   - notebook==5.4.1
   - pip:
-    - nteract_on_jupyter==1.5.0
+    - nteract_on_jupyter==1.6.0

--- a/repo2docker/buildpacks/python/requirements.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements.txt, DO NOT MANUALLY MODIFY
-# Frozen on Tue Mar 20 00:18:43 UTC 2018
+# Frozen on Mon Apr  2 07:17:48 UTC 2018
 bleach==2.1.3
 decorator==4.2.1
 entrypoints==0.2.3
@@ -20,7 +20,7 @@ mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0
 notebook==5.4.1
-nteract-on-jupyter==1.5.0
+nteract-on-jupyter==1.6.0
 pandocfilters==1.4.2
 parso==0.1.1
 pexpect==4.4.0
@@ -28,7 +28,7 @@ pickleshare==0.7.4
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0
-python-dateutil==2.7.0
+python-dateutil==2.7.2
 pyzmq==17.0.0
 Send2Trash==1.5.0
 simplegeneric==0.8.1

--- a/repo2docker/buildpacks/python/requirements.txt
+++ b/repo2docker/buildpacks/python/requirements.txt
@@ -2,4 +2,4 @@ notebook==5.4.1
 tornado==4.5.3
 ipywidgets==7.1.1
 jupyterlab==0.31.5
-nteract_on_jupyter==1.5.0
+nteract_on_jupyter==1.6.0

--- a/repo2docker/buildpacks/python/requirements2.frozen.txt
+++ b/repo2docker/buildpacks/python/requirements2.frozen.txt
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM requirements2.txt, DO NOT MANUALLY MODIFY
-# Frozen on Tue Mar 20 00:20:49 UTC 2018
+# Frozen on Mon Apr  2 07:19:00 UTC 2018
 backports-abc==0.5
 backports.shutil-get-terminal-size==1.0.0
 certifi==2018.1.18
@@ -16,7 +16,7 @@ pickleshare==0.7.4
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0
-python-dateutil==2.7.0
+python-dateutil==2.7.2
 pyzmq==17.0.0
 scandir==1.7
 simplegeneric==0.8.1


### PR DESCRIPTION
Upgraded `nteract_on_jupyter`.

I also took the liberty of gitignoring the conda built outputs that are not tracked (according to https://github.com/jupyter/repo2docker/blob/master/CONTRIBUTING.md#conda-dependencies).