### PR TITLE
split  post build script command in Docker file

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -109,7 +109,8 @@ USER ${NB_USER}
 # Make sure that postBuild scripts are marked executable before executing them
 {% if post_build_scripts -%}
 {% for s in post_build_scripts -%}
-RUN chmod +x {{ s }} && ./{{ s }}
+RUN chmod +x {{ s }}
+RUN ./{{ s }}
 {% endfor %}
 {% endif -%}
 


### PR DESCRIPTION
Hi, `repo2docker` throws `./postBuild: Text file busy` error with Docker version 1.13.1 if there is any postBuild file in repo. This problem is docker related, I don't get the same error when I use Docker version 18.03.0-ce. Splitting docker command fixes it.