### PR TITLE
Use XDG standard ~/.local for user software installs

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -71,9 +71,6 @@ ENV {{item[0]}} {{item[1]}}
 {% endfor -%}
 {% endif -%}
 
-# So users can move executables here with postBuild, issue #557
-ENV PATH '/home/jovyan/local/bin':${PATH}
-
 {% if path -%}
 # Special case PATH
 ENV PATH {{ ':'.join(path) }}:${PATH}
@@ -200,7 +197,10 @@ class BuildPack:
         Just sets the PATH environment variable. Separated out since
         it is very commonly set by various buildpacks.
         """
-        return []
+        # Allow local user installs into ~/.local, which is where the
+        # XDG desktop standard suggests these should be
+        # See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+        return ['$HOME/.local/bin']
 
     def get_labels(self):
         """

--- a/tests/venv/usr-bin/verify
+++ b/tests/venv/usr-bin/verify
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# Verify that ~/local/bin is on the PATH
+import os
+
+PATH = os.getenv("PATH")
+assert "/home/jovyan/local/bin" in PATH

--- a/tests/venv/usr-bin/verify
+++ b/tests/venv/usr-bin/verify
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# Verify that ~/local/bin is on the PATH
+# Verify that ~/.local/bin is on the PATH
 import os
 
-PATH = os.getenv("PATH")
-assert "/home/jovyan/local/bin" in PATH
+assert "$HOME/.local/bin" in os.getenv("PATH")


### PR DESCRIPTION
~/.local is also where things like pip install --user
seem to install things, so we should use that instead of ~/local.
