### PR TITLE
Add DockerSpawner command in JupyterHub config

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -64,7 +64,7 @@ you should put the following in ``requirements.txt`` or ``environment.yml``::
   jupyterhub==0.8.*
 
 If your instance of JupyterHub uses ``DockerSpawner``, you will need to set its
-command to run ``jupyterhub-singleuser``::
+command to run ``jupyterhub-singleuser`` by adding this line in your configuration file::
 
   c.DockerSpawner.cmd = ['jupyterhub-singleuser']
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -63,6 +63,11 @@ you should put the following in ``requirements.txt`` or ``environment.yml``::
 
   jupyterhub==0.8.*
 
+In your JupyterHub configuration, you may also need to pass a command to the Spawner
+to run ``jupyterhub-singleuser``, for instance if using ``DockerSpawner``::
+
+  c.DockerSpawner.cmd = ['jupyterhub-singleuser']
+
 Running ``repo2docker`` locally
 -------------------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -63,8 +63,8 @@ you should put the following in ``requirements.txt`` or ``environment.yml``::
 
   jupyterhub==0.8.*
 
-In your JupyterHub configuration, you may also need to pass a command to the Spawner
-to run ``jupyterhub-singleuser``, for instance if using ``DockerSpawner``::
+If your instance of JupyterHub uses ``DockerSpawner``, you will need to set its
+command to run ``jupyterhub-singleuser``::
 
   c.DockerSpawner.cmd = ['jupyterhub-singleuser']
 


### PR DESCRIPTION
This may be useful to DockerSpawner users who want to create custom images using repo2docker