### PR TITLE
from traitlets import TraitError in utils.py

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 
-from traitlets import Integer
+from traitlets import Integer, TraitError
 
 
 def execute_cmd(cmd, capture=False, **kwargs):


### PR DESCRIPTION
__TraitError__ is used on lines 259 and 266 but it is neither imported nor defined which will cause a __NameError__ to be raised instead of a __TraitError__.

flake8 testing of https://github.com/jupyter/repo2docker on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./repo2docker/utils.py:259:19: F821 undefined name 'TraitError'
            raise TraitError(
                  ^
./repo2docker/utils.py:266:19: F821 undefined name 'TraitError'
            raise TraitError(
                  ^
2     F821 undefined name 'TraitError'
2
```