### PR TITLE
[MRG] Add version argument

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -367,6 +367,8 @@ class Repo2Docker(Application):
         if argv is None:
             argv = sys.argv[1:]
 
+        # version must be checked before parse, as repo/cmd are required and
+        # will spit out an error if allowed to be parsed first.
         if '--version' in argv:
             print(self.version)
             sys.exit(0)

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -351,7 +351,6 @@ class Repo2Docker(Application):
             help='Print the repo2docker version and exit.'
         )
 
-
         return argparser
 
     def json_excepthook(self, etype, evalue, traceback):
@@ -362,7 +361,6 @@ class Repo2Docker(Application):
         self.log.error("Error during build: %s", evalue,
                        exc_info=(etype, evalue, traceback),
                        extra=dict(phase='failed'))
-
 
     def initialize(self, argv=None):
         """Init repo2docker configuration before start"""

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -217,6 +217,7 @@ class Repo2Docker(Application):
     def get_argparser(self):
         """Get arguments that may be used by repo2docker"""
         argparser = argparse.ArgumentParser()
+
         argparser.add_argument(
             '--config',
             default='repo2docker_config.py',
@@ -342,6 +343,15 @@ class Repo2Docker(Application):
             type=str,
             help=self.traits()['appendix'].help,
         )
+
+        argparser.add_argument(
+            '--version',
+            dest='version',
+            action='store_true',
+            help='Print the repo2docker version and exit.'
+        )
+
+
         return argparser
 
     def json_excepthook(self, etype, evalue, traceback):
@@ -353,10 +363,16 @@ class Repo2Docker(Application):
                        exc_info=(etype, evalue, traceback),
                        extra=dict(phase='failed'))
 
+
     def initialize(self, argv=None):
         """Init repo2docker configuration before start"""
         if argv is None:
             argv = sys.argv[1:]
+
+        if '--version' in argv:
+            print(self.version)
+            sys.exit(0)
+
         args = self.get_argparser().parse_args(argv)
 
         if args.debug:


### PR DESCRIPTION
This pull request will add a `--version` option to the jupyter-repo2docker client, so the user can do:

```bash
$ jupyter-repo2docker --version
v0.5+234.g5c263a9.dirty
```
Since the repo and cmd are required arguments (and it would get angry without them) the easiest way to do this is to check for `--version` in the arguments **before** it's parsed by the argparser. The other way I've done is to have subcommands, but that would require a large change to the user interaction (and I don't think necessary). This will close #349 