### PR TITLE
bump versions and refreeze

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,29 +1,34 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-05-08 20:22:20 UTC
+# Frozen on 2018-07-16 23:09:21 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - attrs=18.1.0=py_1
+  - automat=0.7.0=py36_0
   - backcall=0.1.0=py_0
   - bleach=2.1.3=py_0
   - ca-certificates=2018.4.16=0
   - certifi=2018.4.16=py36_0
+  - constantly=15.1.0=py_0
   - decorator=4.3.0=py_0
   - entrypoints=0.2.3=py36_1
-  - gmp=6.1.2=0
+  - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
+  - hyperlink=17.3.1=py_0
+  - incremental=17.5.0=py_0
   - ipykernel=4.8.2=py36_0
-  - ipython=6.3.1=py36_0
-  - ipython_genutils=0.2.0=py36_0
-  - ipywidgets=7.1.1=py36_0
-  - jedi=0.12.0=py36_0
-  - jinja2=2.10=py36_0
+  - ipython=6.4.0=py36_0
+  - ipython_genutils=0.2.0=py_1
+  - ipywidgets=7.2.1=py36_1
+  - jedi=0.12.1=py36_0
+  - jinja2=2.10=py_1
   - jsonschema=2.6.0=py36_1
-  - jupyter_client=5.2.3=py36_0
+  - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.31.5=py36_1
+  - jupyterlab=0.32.1=py36_0
   - jupyterlab_launcher=0.10.5=py36_0
   - libsodium=1.0.16=0
   - markupsafe=1.0=py36_0
@@ -31,24 +36,25 @@ dependencies:
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py36_0
   - ncurses=5.9=10
-  - notebook=5.4.1=py36_0
+  - notebook=5.6.0=py36_0
   - openssl=1.0.2o=0
-  - pandoc=2.2=0
-  - pandocfilters=1.4.2=py36_0
-  - parso=0.2.0=py_0
-  - pexpect=4.5.0=py36_0
+  - pandoc=2.2.2=0
+  - pandocfilters=1.4.2=py_1
+  - parso=0.3.0=py_0
+  - pexpect=4.6.0=py36_0
   - pickleshare=0.7.4=py36_0
   - pip=9.0.3=py36_0
+  - prometheus_client=0.2.0=py36_0
   - prompt_toolkit=1.0.15=py36_0
-  - ptyprocess=0.5.2=py36_0
-  - pygments=2.2.0=py36_0
+  - ptyprocess=0.6.0=py36_0
+  - pygments=2.2.0=py_1
   - python=3.6.5=1
-  - python-dateutil=2.7.2=py_0
-  - pyzmq=17.0.0=py36_4
+  - python-dateutil=2.7.3=py_0
+  - pyzmq=17.1.0=py36hae99301_0
   - readline=7.0=0
   - send2trash=1.5.0=py_0
-  - setuptools=39.1.0=py36_0
-  - simplegeneric=0.8.1=py36_0
+  - setuptools=40.0.0=py36_0
+  - simplegeneric=0.8.1=py_1
   - six=1.11.0=py36_1
   - sqlite=3.20.1=2
   - terminado=0.8.1=py36_0
@@ -56,14 +62,18 @@ dependencies:
   - tk=8.6.7=0
   - tornado=4.5.3=py36_0
   - traitlets=4.3.2=py36_0
-  - wcwidth=0.1.7=py36_0
+  - wcwidth=0.1.7=py_1
   - webencodings=0.5=py36_0
-  - wheel=0.31.0=py36_0
+  - wheel=0.31.1=py36_0
   - widgetsnbextension=3.2.1=py36_0
   - xz=5.2.3=0
-  - zeromq=4.2.5=1
-  - zlib=1.2.11=0
+  - zeromq=4.2.5=hfc679d8_3
+  - zlib=1.2.11=h470a237_3
+  - zope.interface=4.5.0=py36h470a237_0
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libstdcxx-ng=7.2.0=hdf63c60_3
+  - twisted=17.5.0=py36_0
   - pip:
-    - nteract-on-jupyter==1.7.0
+    - nteract-on-jupyter==1.8.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-05-08 20:15:09 UTC
+# Frozen on 2018-07-16 23:03:29 UTC
 name: r2d
 channels:
   - conda-forge
@@ -14,27 +14,27 @@ dependencies:
   - decorator=4.3.0=py_0
   - enum34=1.1.6=py27_1
   - ipykernel=4.8.2=py27_0
-  - ipython=5.6.0=py27_0
-  - ipython_genutils=0.2.0=py27_0
-  - jupyter_client=5.2.3=py27_0
+  - ipython=5.7.0=py27_0
+  - ipython_genutils=0.2.0=py_1
+  - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
   - libsodium=1.0.16=0
   - ncurses=5.9=10
   - openssl=1.0.2o=0
   - pathlib2=2.3.2=py27_0
-  - pexpect=4.5.0=py27_0
+  - pexpect=4.6.0=py27_0
   - pickleshare=0.7.4=py27_0
   - pip=9.0.3=py27_0
   - prompt_toolkit=1.0.15=py27_0
-  - ptyprocess=0.5.2=py27_0
-  - pygments=2.2.0=py27_0
+  - ptyprocess=0.6.0=py27_0
+  - pygments=2.2.0=py_1
   - python=2.7.15=0
-  - python-dateutil=2.7.2=py_0
-  - pyzmq=17.0.0=py27_4
+  - python-dateutil=2.7.3=py_0
+  - pyzmq=17.1.0=py27hae99301_0
   - readline=7.0=0
-  - scandir=1.7=py27_0
-  - setuptools=39.1.0=py27_0
-  - simplegeneric=0.8.1=py27_0
+  - scandir=1.7=py27h470a237_1
+  - setuptools=40.0.0=py27_0
+  - simplegeneric=0.8.1=py_1
   - singledispatch=3.4.0.3=py27_0
   - six=1.11.0=py27_1
   - sqlite=3.20.1=2
@@ -42,10 +42,12 @@ dependencies:
   - tk=8.6.7=0
   - tornado=4.5.3=py27_0
   - traitlets=4.3.2=py27_0
-  - wcwidth=0.1.7=py27_0
-  - wheel=0.31.0=py27_0
-  - zeromq=4.2.5=1
-  - zlib=1.2.11=0
+  - wcwidth=0.1.7=py_1
+  - wheel=0.31.1=py27_0
+  - zeromq=4.2.5=hfc679d8_3
+  - zlib=1.2.11=h470a237_3
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libstdcxx-ng=7.2.0=hdf63c60_3
   - pip:
     - backports.ssl-match-hostname==3.5.0.1
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,29 +1,34 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-05-08 20:18:13 UTC
+# Frozen on 2018-07-16 23:05:45 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - attrs=18.1.0=py_1
+  - automat=0.7.0=py35_0
   - backcall=0.1.0=py_0
   - bleach=2.1.3=py_0
   - ca-certificates=2018.4.16=0
   - certifi=2018.4.16=py35_0
+  - constantly=15.1.0=py_0
   - decorator=4.3.0=py_0
   - entrypoints=0.2.3=py35_1
-  - gmp=6.1.2=0
+  - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
+  - hyperlink=17.3.1=py_0
+  - incremental=17.5.0=py_0
   - ipykernel=4.8.2=py35_0
-  - ipython=6.3.1=py35_0
-  - ipython_genutils=0.2.0=py35_0
-  - ipywidgets=7.1.1=py35_0
-  - jedi=0.12.0=py35_0
-  - jinja2=2.10=py35_0
+  - ipython=6.4.0=py35_0
+  - ipython_genutils=0.2.0=py_1
+  - ipywidgets=7.2.1=py35_1
+  - jedi=0.12.1=py35_0
+  - jinja2=2.10=py_1
   - jsonschema=2.6.0=py35_1
-  - jupyter_client=5.2.3=py35_0
+  - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.31.5=py35_1
+  - jupyterlab=0.32.1=py35_0
   - jupyterlab_launcher=0.10.5=py35_0
   - libsodium=1.0.16=0
   - markupsafe=1.0=py35_0
@@ -31,24 +36,25 @@ dependencies:
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py35_0
   - ncurses=5.9=10
-  - notebook=5.4.1=py35_0
+  - notebook=5.6.0=py35_0
   - openssl=1.0.2o=0
-  - pandoc=2.2=0
-  - pandocfilters=1.4.2=py35_0
-  - parso=0.2.0=py_0
-  - pexpect=4.5.0=py35_0
+  - pandoc=2.2.2=0
+  - pandocfilters=1.4.2=py_1
+  - parso=0.3.0=py_0
+  - pexpect=4.6.0=py35_0
   - pickleshare=0.7.4=py35_0
   - pip=9.0.3=py35_0
+  - prometheus_client=0.2.0=py35_0
   - prompt_toolkit=1.0.15=py35_0
-  - ptyprocess=0.5.2=py35_0
-  - pygments=2.2.0=py35_0
+  - ptyprocess=0.6.0=py35_0
+  - pygments=2.2.0=py_1
   - python=3.5.5=1
-  - python-dateutil=2.7.2=py_0
-  - pyzmq=17.0.0=py35_4
+  - python-dateutil=2.7.3=py_0
+  - pyzmq=17.1.0=py35hae99301_0
   - readline=7.0=0
   - send2trash=1.5.0=py_0
-  - setuptools=39.1.0=py35_0
-  - simplegeneric=0.8.1=py35_0
+  - setuptools=40.0.0=py35_0
+  - simplegeneric=0.8.1=py_1
   - six=1.11.0=py35_1
   - sqlite=3.20.1=2
   - terminado=0.8.1=py35_0
@@ -56,14 +62,18 @@ dependencies:
   - tk=8.6.7=0
   - tornado=4.5.3=py35_0
   - traitlets=4.3.2=py35_0
-  - wcwidth=0.1.7=py35_0
+  - wcwidth=0.1.7=py_1
   - webencodings=0.5=py35_0
-  - wheel=0.31.0=py35_0
+  - wheel=0.31.1=py35_0
   - widgetsnbextension=3.2.1=py35_0
   - xz=5.2.3=0
-  - zeromq=4.2.5=1
-  - zlib=1.2.11=0
+  - zeromq=4.2.5=hfc679d8_3
+  - zlib=1.2.11=h470a237_3
+  - zope.interface=4.5.0=py35h470a237_0
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libstdcxx-ng=7.2.0=hdf63c60_3
+  - twisted=17.5.0=py35_0
   - pip:
-    - nteract-on-jupyter==1.7.0
+    - nteract-on-jupyter==1.8.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,29 +1,34 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-05-08 20:22:20 UTC
+# Frozen on 2018-07-16 23:09:21 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - attrs=18.1.0=py_1
+  - automat=0.7.0=py36_0
   - backcall=0.1.0=py_0
   - bleach=2.1.3=py_0
   - ca-certificates=2018.4.16=0
   - certifi=2018.4.16=py36_0
+  - constantly=15.1.0=py_0
   - decorator=4.3.0=py_0
   - entrypoints=0.2.3=py36_1
-  - gmp=6.1.2=0
+  - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
+  - hyperlink=17.3.1=py_0
+  - incremental=17.5.0=py_0
   - ipykernel=4.8.2=py36_0
-  - ipython=6.3.1=py36_0
-  - ipython_genutils=0.2.0=py36_0
-  - ipywidgets=7.1.1=py36_0
-  - jedi=0.12.0=py36_0
-  - jinja2=2.10=py36_0
+  - ipython=6.4.0=py36_0
+  - ipython_genutils=0.2.0=py_1
+  - ipywidgets=7.2.1=py36_1
+  - jedi=0.12.1=py36_0
+  - jinja2=2.10=py_1
   - jsonschema=2.6.0=py36_1
-  - jupyter_client=5.2.3=py36_0
+  - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.31.5=py36_1
+  - jupyterlab=0.32.1=py36_0
   - jupyterlab_launcher=0.10.5=py36_0
   - libsodium=1.0.16=0
   - markupsafe=1.0=py36_0
@@ -31,24 +36,25 @@ dependencies:
   - nbconvert=5.3.1=py_1
   - nbformat=4.4.0=py36_0
   - ncurses=5.9=10
-  - notebook=5.4.1=py36_0
+  - notebook=5.6.0=py36_0
   - openssl=1.0.2o=0
-  - pandoc=2.2=0
-  - pandocfilters=1.4.2=py36_0
-  - parso=0.2.0=py_0
-  - pexpect=4.5.0=py36_0
+  - pandoc=2.2.2=0
+  - pandocfilters=1.4.2=py_1
+  - parso=0.3.0=py_0
+  - pexpect=4.6.0=py36_0
   - pickleshare=0.7.4=py36_0
   - pip=9.0.3=py36_0
+  - prometheus_client=0.2.0=py36_0
   - prompt_toolkit=1.0.15=py36_0
-  - ptyprocess=0.5.2=py36_0
-  - pygments=2.2.0=py36_0
+  - ptyprocess=0.6.0=py36_0
+  - pygments=2.2.0=py_1
   - python=3.6.5=1
-  - python-dateutil=2.7.2=py_0
-  - pyzmq=17.0.0=py36_4
+  - python-dateutil=2.7.3=py_0
+  - pyzmq=17.1.0=py36hae99301_0
   - readline=7.0=0
   - send2trash=1.5.0=py_0
-  - setuptools=39.1.0=py36_0
-  - simplegeneric=0.8.1=py36_0
+  - setuptools=40.0.0=py36_0
+  - simplegeneric=0.8.1=py_1
   - six=1.11.0=py36_1
   - sqlite=3.20.1=2
   - terminado=0.8.1=py36_0
@@ -56,14 +62,18 @@ dependencies:
   - tk=8.6.7=0
   - tornado=4.5.3=py36_0
   - traitlets=4.3.2=py36_0
-  - wcwidth=0.1.7=py36_0
+  - wcwidth=0.1.7=py_1
   - webencodings=0.5=py36_0
-  - wheel=0.31.0=py36_0
+  - wheel=0.31.1=py36_0
   - widgetsnbextension=3.2.1=py36_0
   - xz=5.2.3=0
-  - zeromq=4.2.5=1
-  - zlib=1.2.11=0
+  - zeromq=4.2.5=hfc679d8_3
+  - zlib=1.2.11=h470a237_3
+  - zope.interface=4.5.0=py36h470a237_0
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libstdcxx-ng=7.2.0=hdf63c60_3
+  - twisted=17.5.0=py36_0
   - pip:
-    - nteract-on-jupyter==1.7.0
+    - nteract-on-jupyter==1.8.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,8 +1,8 @@
 dependencies:
   - python=3.6.*
-  - ipywidgets==7.1.1
-  - jupyterlab==0.31.5
+  - ipywidgets==7.2.1
+  - jupyterlab==0.32.1
   - tornado==4.5.3
-  - notebook==5.4.1
+  - notebook==5.6.0
   - pip:
-    - nteract_on_jupyter==1.7.0
+    - nteract_on_jupyter==1.8.1

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -19,9 +19,7 @@ import sys
 from ruamel.yaml import YAML
 
 
-MINICONDA_VERSION = '4.3.27'
-# need conda ≥ 4.4 to avoid bug adding spurious pip dependencies
-CONDA_VERSION = '4.4.11'
+MINICONDA_VERSION = '4.5.4'
 
 HERE = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 
@@ -59,7 +57,7 @@ def freeze(env_file, frozen_file):
         f"continuumio/miniconda3:{MINICONDA_VERSION}",
         "sh", "-c",
         '; '.join([
-            f"conda install -yq conda={CONDA_VERSION}",
+            # f"conda install -yq conda={CONDA_VERSION}",
             'conda config --add channels conda-forge',
             'conda config --system --set auto_update_conda false',
             f"conda env create -v -f /r2d/{env_file} -n r2d",

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -3,8 +3,9 @@
 set -ex
 
 cd $(dirname $0)
-CONDA_VERSION=4.5.1
-URL="https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"
+MINICONDA_VERSION=4.5.4
+CONDA_VERSION=4.5.8
+URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 
 wget --quiet $URL -O ${INSTALLER_PATH}
@@ -12,7 +13,7 @@ chmod +x ${INSTALLER_PATH}
 
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="0c28787e3126238df24c5d4858bd0744"
+MD5SUM="a946ea1d0c4a642ddf0c3a26a18bb16d"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
@@ -28,6 +29,9 @@ conda config --system --add channels conda-forge
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true
+
+# install conda itself
+conda install -yq conda==${CONDA_VERSION}
 
 # switch Python in its own step
 # since switching Python during an env update can


### PR DESCRIPTION
gets notebook 5.6, which includes fixes that blocked 5.5 in #325

A subsequent PR (@GladysNalvarte is working on this) can set the display_url so that it's guaranteed to be correct when run in repo2docker, which has never been the case before.