### PR TITLE
remove conda-meta/history

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -57,8 +57,12 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
 
     conda env create -n kernel -f /tmp/kernel-environment.yml
     ${CONDA_DIR}/envs/kernel/bin/ipython kernel install --prefix "${CONDA_DIR}"
+    rm -f ${CONDA_DIR}/envs/kernel/conda-meta/history
 fi
-
+# remove conda history file,
+# which seems to result in some effective pinning of packages in the initial env,
+# which we don't intend
+rm -f ${CONDA_DIR}/conda-meta/history
 # Clean things out!
 conda clean -tipsy
 

--- a/tests/external/reproductions.repos.yaml
+++ b/tests/external/reproductions.repos.yaml
@@ -24,3 +24,9 @@
   url: https://github.com/binder-examples/requirements
   ref: test
   verify: python -c 'import matplotlib'
+# Test that custom channels and downgrades don't
+# get blocked by pinning
+- name: Xeus-Cling
+  url: https://github.com/QuantStack/xeus-cling
+  ref: 0.4.5
+  verify: jupyter kernelspec list


### PR DESCRIPTION
this file records transactions and seems to result in effectively turning the initial env install into a restrictive pinning, which we do not intend.

Adds xeus-cling@0.4.5 to external tests, since this repo cannot be built due to this effective pinning, but seems to build after removing the history file. It's very weird, and I'm not sure if it's intended behavior of conda or not.

cc @SylvainCorlay