### PR TITLE
Issue #388 - Use bash echo for git-credential-env

### DIFF
--- a/docker/git-credential-env
+++ b/docker/git-credential-env
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 echo -e $GIT_CREDENTIAL_ENV


### PR DESCRIPTION
sh is not consistent in its support of the echo builtin's -e flag. On
debian sh is symlinked to dash, which does not support the flag
resulting in bad credential output. Unfortunately /bin/echo is also
nonstandard - e.g. on macs -e is not supported while it is on debian. I
think the best approach is to rely on bash's echo builtin which should
be consistent across systems (at the slight cost of requiring bash as a
dependency)

This solves issue #388 