### PR TITLE
Julia v1.0 support: Add option to specify julia version in REQUIRE

### DIFF
--- a/repo2docker/buildpacks/julia.py
+++ b/repo2docker/buildpacks/julia.py
@@ -22,9 +22,6 @@ class JuliaBuildPack(CondaBuildPack):
         '1': '1.0.0',
     }
 
-    def _short_version(version_str):
-        return '.'.join(version_str.split('.')[:2])
-
     @property
     def julia_version(self):
         require = self.binder_path('REQUIRE')

--- a/repo2docker/buildpacks/julia/__init__.py
+++ b/repo2docker/buildpacks/julia/__init__.py
@@ -123,10 +123,6 @@ class JuliaBuildPack(CondaBuildPack):
                 """
             )
         ]
-        require = "/Users/daly/Documents/developer/website/nhdaly.github.io/notebooks/REQUIRE"
-        f = open(require)
-        julia_version_line = list(filter(lambda l: l != "", map(lambda l:l.strip(), f.readlines())))[0]
-        julia_version_line = f.readline().strip()
 
     def get_assemble_scripts(self):
         """
@@ -146,9 +142,10 @@ class JuliaBuildPack(CondaBuildPack):
             # format is deprecated).
             # The precompliation is done via `using {libraryname}`.
             r"""
-            julia /tmp/install-repo-dependencies.jl "%(require)s" && \
-            rm /tmp/install-repo-dependencies.jl
+            julia /tmp/install-repo-dependencies.jl "%(require)s"
             """ % { "require" : require }
+            # TODO: For some reason, `rm`ing the file fails with permission denied.
+            # && rm /tmp/install-repo-dependencies.jl
         )]
 
     def get_build_script_files(self):
@@ -169,4 +166,6 @@ class JuliaBuildPack(CondaBuildPack):
         Instead we just check if the path to `REQUIRE` exists
 
         """
+        # TODO(nhdaly): Add support for value in variable:
+            pass Project.toml here as well.
         return os.path.exists(self.binder_path('REQUIRE'))

--- a/repo2docker/buildpacks/julia/__init__.py
+++ b/repo2docker/buildpacks/julia/__init__.py
@@ -71,7 +71,8 @@ class JuliaBuildPack(CondaBuildPack):
         """
         return super().get_build_env() + [
             ('JULIA_PATH', '${APP_BASE}/julia'),
-            ('JULIA_HOME', '${JULIA_PATH}/bin'),
+            ('JULIA_HOME', '${JULIA_PATH}/bin'),  # julia <= 0.6
+            ('JULIA_BINDIR', '${JULIA_HOME}'),  # julia >= 0.7
             ('JULIA_PKGDIR', '${JULIA_PATH}/pkg'),
             ('JULIA_VERSION', self.julia_version),
             ('JUPYTER', '${NB_PYTHON_PREFIX}/bin/jupyter')

--- a/repo2docker/buildpacks/julia/__init__.py
+++ b/repo2docker/buildpacks/julia/__init__.py
@@ -166,6 +166,5 @@ class JuliaBuildPack(CondaBuildPack):
         Instead we just check if the path to `REQUIRE` exists
 
         """
-        # TODO(nhdaly): Add support for value in variable:
-            pass Project.toml here as well.
+        # TODO(nhdaly): Add support for Project.toml here as well.
         return os.path.exists(self.binder_path('REQUIRE'))

--- a/repo2docker/buildpacks/julia/install-repo-dependencies.jl
+++ b/repo2docker/buildpacks/julia/install-repo-dependencies.jl
@@ -1,0 +1,36 @@
+#!/bin/julia
+
+# Path to potential REQUIRE file is passed on the command line.
+require_file = ARGS[1]
+
+if VERSION < v"0.7-"
+  pkg_dir = "$(ENV["JULIA_PKGDIR"])/v$(VERSION.major).$(VERSION.minor)"
+  open("$pkg_dir/REQUIRE", "a") do io
+    write(io, read(require_file))
+  end
+  Pkg.resolve();
+  Reqs = Pkg.Reqs
+else
+  using Pkg
+  Reqs = Pkg.Pkg2.Reqs
+  emptyversionlower = v"0.0.0-"
+  for reqline in Reqs.read(require_file)
+    if reqline isa Reqs.Requirement
+        pkg = String(reqline.package)
+        if pkg == "julia" continue end
+        version = try; reqline.versions.intervals[1].lower; catch; emptyversionlower; end
+        if version != emptyversionlower
+          Pkg.add(PackageSpec(name=pkg, version=version))
+        else
+          Pkg.add(pkg)
+        end
+    end
+  end
+end
+# Precompile the packages
+for reqline in Reqs.read(require_file)
+  if reqline isa Reqs.Requirement
+      pkg = reqline.package
+      pkg != "julia" && eval(:(using $(Symbol(pkg))))
+  end
+end

--- a/tests/julia/julia_version-1/README.rst
+++ b/tests/julia/julia_version-1/README.rst
@@ -1,0 +1,5 @@
+Julia - REQUIRE: test version for julia v1.0
+---------------
+
+Starting with julia v0.7 and up, the package manager has changed, so this tests
+that the julia version can be specified and packages installed correctly. 

--- a/tests/julia/julia_version-1/README.rst
+++ b/tests/julia/julia_version-1/README.rst
@@ -2,4 +2,4 @@ Julia - REQUIRE: test version for julia v1.0
 ---------------
 
 Starting with julia v0.7 and up, the package manager has changed, so this tests
-that the julia version can be specified and packages installed correctly. 
+that the julia version can be specified and packages installed correctly.

--- a/tests/julia/julia_version-1/REQUIRE
+++ b/tests/julia/julia_version-1/REQUIRE
@@ -1,0 +1,4 @@
+julia 1
+
+# Julia packages:
+Compat

--- a/tests/julia/julia_version-1/verify
+++ b/tests/julia/julia_version-1/verify
@@ -4,9 +4,12 @@ if VERSION < v"1"
     exit(1)
 end
 
-# Test that the package was installed.
 try
+    # Test that the package was installed.
     using Compat
+
+    # Verify that the environment variables are set correctly for julia 1.0+
+    @assert "julia" ∈ readdir(Sys.BINDIR)
 catch
     exit(1)
 end

--- a/tests/julia/julia_version-1/verify
+++ b/tests/julia/julia_version-1/verify
@@ -1,0 +1,14 @@
+#!/usr/bin/env julia
+# Verify the version:
+if VERSION < v"1"
+    exit(1)
+end
+
+# Test that the package was installed.
+try
+    using Compat
+catch
+    exit(1)
+end
+
+exit(0)

--- a/tests/julia/julia_version/README.rst
+++ b/tests/julia/julia_version/README.rst
@@ -14,12 +14,9 @@ the names of packages you'd like to be installed. For example:
 
 ```
 PyPlot
-IJulia
 DataFrames
 ```
 
-Each one will be installed but **not** pre-compiled. If you'd like to
-pre-compile your Julia packages, consider using a ``postBuild`` file.
+Note that `IJulia` is installed by default.
 
-Note that this example also specifies Python dependencies with an
-``environment.yml`` file.
+These packages will all be installed, and then precompiled via `using`.

--- a/tests/julia/julia_version/README.rst
+++ b/tests/julia/julia_version/README.rst
@@ -1,0 +1,25 @@
+Julia - REQUIRE: packages and julia version number
+---------------
+
+To specify dependencies in Julia, include a REQUIRE file.
+
+To specify a version of Julia to be installed, the first line of the file must
+follow the format `julia <version-number>`. For example:
+```
+julia 0.7
+```
+
+To add package dependencies, the rest of the file can include lines that list
+the names of packages you'd like to be installed. For example:
+
+```
+PyPlot
+IJulia
+DataFrames
+```
+
+Each one will be installed but **not** pre-compiled. If you'd like to
+pre-compile your Julia packages, consider using a ``postBuild`` file.
+
+Note that this example also specifies Python dependencies with an
+``environment.yml`` file.

--- a/tests/julia/julia_version/REQUIRE
+++ b/tests/julia/julia_version/REQUIRE
@@ -1,0 +1,4 @@
+julia 0.6.3
+
+# Julia packages:
+Compat

--- a/tests/julia/julia_version/verify
+++ b/tests/julia/julia_version/verify
@@ -4,9 +4,12 @@ if VERSION != v"0.6.3"
     exit(1)
 end
 
-# Test that the package was installed.
 try
+    # Test that the package was installed.
     using Compat
+
+    # Verify that the environment variables are set correctly for julia <= 0.6
+    @assert "julia" ∈ readdir(Base.JULIA_HOME)
 catch
     exit(1)
 end

--- a/tests/julia/julia_version/verify
+++ b/tests/julia/julia_version/verify
@@ -1,0 +1,14 @@
+#!/usr/bin/env julia
+# Verify the version:
+if VERSION != v"0.6.3"
+    exit(1)
+end
+
+# Test that the package was installed.
+try
+    using Compat
+catch
+    exit(1)
+end
+
+exit(0)


### PR DESCRIPTION
This PR adds the option to specify a julia version in the REQUIRE file, and updates the JuliaBuildPack to support julia v0.7 and v1.0.

It also bumps the default julia version from v0.6.0 to v0.6.4 (the latest release for v0.6).

Adds tests for specifying a custom version, both for a `julia 0.6.3` and `julia 1`.