### PR TITLE
Fix relative location of the start script

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -543,7 +543,7 @@ class BaseImage(BuildPack):
         return []
 
     def get_start_script(self):
-        start = self.binder_path('start')
+        start = self.binder_path('./start')
         if os.path.exists(start):
             return start
         return None


### PR DESCRIPTION
The compilation of a very simple example with a start
script in the main folder was failing (see #399)
because the `start` script was not found.
Most probably, the reason is that the folder in which
the script resides is not in the PATH. To solve this,
we replace the `start` string with a relative `./start`,
which solves the problem and completes the build and the
run.

This fixes #399 