### PR TITLE
Support python 3.7

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -3,9 +3,44 @@
 A collection of frequently asked questions with answers. If you have a question
 and have found an answer, send a PR to add it here!
 
-## How should I specify another version of Python 3?
+## How should I specify another version of Python?
 
 One can specify a Python version in the ``environment.yml`` file of a repository.
+
+## What versions of Python (or R or Julia...) are supported?
+
+### Python
+
+Repo2docker officially supports the following versions of Python (specified in environment.yml or runtime.txt):
+
+- 3.7 (added in 0.7)
+- 3.6 (default)
+- 3.5
+
+Additional versions may work, as long as the
+[base environment](https://github.com/jupyter/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml)
+can be installed for your version of Python.
+The most likely source of incompatibility is if one of the packages
+in the base environment is not packaged for your Python,
+either because the version of the package is too new and your chosen Python is too old,
+or vice versa.
+
+Additionally, if Python 2.7 is specified,
+a separate environment for the kernel will be installed with Python 2.
+The notebook server will run in the default Python 3.6 environment.
+
+### Julia
+
+The following versions of Julia are supported (specified in REQUIRE):
+
+- 1.0 (added in 0.7)
+- 0.7 (added in 0.7)
+- 0.6 (default)
+
+### R
+
+Only R 3.4.4 is currently supported, which is installed via `apt` from the
+[ubuntu bionic repository](https://packages.ubuntu.com/bionic/r-base).
 
 ## Can I add executable files to the user's PATH?
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-09-07 17:36:45 UTC
+# Frozen on 2018-09-17 08:27:26 UTC
 name: r2d
 channels:
   - conda-forge

--- a/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.5.frozen.yml
@@ -1,32 +1,21 @@
 # AUTO GENERATED FROM environment.py-3.5.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-09-07 17:39:09 UTC
+# Frozen on 2018-09-17 08:33:33 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - appdirs=1.4.3=py_1
-  - asn1crypto=0.24.0=py35_3
-  - attrs=18.2.0=py_0
-  - automat=0.7.0=py_1
   - backcall=0.1.0=py_0
   - bleach=2.1.4=py_1
   - bzip2=1.0.6=h470a237_2
   - ca-certificates=2018.8.24=ha4d7672_0
   - certifi=2018.8.24=py35_1
-  - cffi=1.11.5=py35h5e8e0c9_1
-  - constantly=15.1.0=py_0
-  - cryptography=2.3.1=py35hdffb7b8_0
-  - cryptography-vectors=2.3.1=py35_0
   - decorator=4.3.0=py_0
   - defusedxml=0.5.0=py35_0
   - entrypoints=0.2.3=py35_2
   - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
-  - hyperlink=17.3.1=py_0
-  - idna=2.7=py35_2
-  - incremental=17.5.0=py_0
   - ipykernel=4.9.0=py35_0
   - ipython=6.5.0=py35_0
   - ipython_genutils=0.2.0=py_1
@@ -36,7 +25,7 @@ dependencies:
   - jsonschema=2.6.0=py35_2
   - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.34.0=py35_0
+  - jupyterlab=0.34.9=py35_0
   - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
@@ -44,32 +33,26 @@ dependencies:
   - libstdcxx-ng=7.2.0=hdf63c60_3
   - markupsafe=1.0=py35h470a237_1
   - mistune=0.8.3=py35h470a237_2
-  - nbconvert=5.4.0=0
+  - nbconvert=5.4.0=1
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_1
   - notebook=5.6.0=py35_1
   - openssl=1.0.2p=h470a237_0
-  - pandoc=2.2.2=1
+  - pandoc=1.19.2=0
   - pandocfilters=1.4.2=py_1
   - parso=0.3.1=py_0
   - pexpect=4.6.0=py35_0
   - pickleshare=0.7.4=py35_0
   - pip=18.0=py35_1
-  - prometheus_client=0.3.0=py_0
+  - prometheus_client=0.3.1=py_1
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py35_0
-  - pyasn1=0.4.4=py_0
-  - pyasn1-modules=0.2.1=py_0
-  - pycparser=2.18=py_1
   - pygments=2.2.0=py_1
-  - pyhamcrest=1.9.0=py_2
-  - pyopenssl=18.0.0=py35_0
   - python=3.5.5=h5001a0f_2
   - python-dateutil=2.7.3=py_0
   - pyzmq=17.1.2=py35hae99301_0
   - readline=7.0=haf1bffa_1
   - send2trash=1.5.0=py_0
-  - service_identity=17.0.0=py_0
   - setuptools=40.2.0=py35_0
   - simplegeneric=0.8.1=py_1
   - six=1.11.0=py35_1
@@ -79,7 +62,6 @@ dependencies:
   - tk=8.6.8=0
   - tornado=4.5.3=py35_0
   - traitlets=4.3.2=py35_0
-  - twisted=18.7.0=py35h470a237_1
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.31.1=py35_1
@@ -87,7 +69,6 @@ dependencies:
   - xz=5.2.4=h470a237_1
   - zeromq=4.2.5=hfc679d8_5
   - zlib=1.2.11=h470a237_3
-  - zope.interface=4.5.0=py35h470a237_1
   - pip:
     - nteract-on-jupyter==1.9.6
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,32 +1,21 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-09-07 17:44:07 UTC
+# Frozen on 2018-09-17 08:36:41 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - appdirs=1.4.3=py_1
-  - asn1crypto=0.24.0=py36_3
-  - attrs=18.2.0=py_0
-  - automat=0.7.0=py_1
   - backcall=0.1.0=py_0
   - bleach=2.1.4=py_1
   - bzip2=1.0.6=h470a237_2
   - ca-certificates=2018.8.24=ha4d7672_0
   - certifi=2018.8.24=py36_1
-  - cffi=1.11.5=py36h5e8e0c9_1
-  - constantly=15.1.0=py_0
-  - cryptography=2.3.1=py36hdffb7b8_0
-  - cryptography-vectors=2.3.1=py36_0
   - decorator=4.3.0=py_0
   - defusedxml=0.5.0=py36_0
   - entrypoints=0.2.3=py36_2
   - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
-  - hyperlink=17.3.1=py_0
-  - idna=2.7=py36_2
-  - incremental=17.5.0=py_0
   - ipykernel=4.9.0=py36_0
   - ipython=6.5.0=py36_0
   - ipython_genutils=0.2.0=py_1
@@ -36,7 +25,7 @@ dependencies:
   - jsonschema=2.6.0=py36_2
   - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.34.0=py36_0
+  - jupyterlab=0.34.9=py36_0
   - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
@@ -44,32 +33,26 @@ dependencies:
   - libstdcxx-ng=7.2.0=hdf63c60_3
   - markupsafe=1.0=py36h470a237_1
   - mistune=0.8.3=py36h470a237_2
-  - nbconvert=5.4.0=0
+  - nbconvert=5.4.0=1
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_1
   - notebook=5.6.0=py36_1
   - openssl=1.0.2p=h470a237_0
-  - pandoc=2.2.2=1
+  - pandoc=1.19.2=0
   - pandocfilters=1.4.2=py_1
   - parso=0.3.1=py_0
   - pexpect=4.6.0=py36_0
   - pickleshare=0.7.4=py36_0
   - pip=18.0=py36_1
-  - prometheus_client=0.3.0=py_0
+  - prometheus_client=0.3.1=py_1
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py36_0
-  - pyasn1=0.4.4=py_0
-  - pyasn1-modules=0.2.1=py_0
-  - pycparser=2.18=py_1
   - pygments=2.2.0=py_1
-  - pyhamcrest=1.9.0=py_2
-  - pyopenssl=18.0.0=py36_0
   - python=3.6.6=h5001a0f_0
   - python-dateutil=2.7.3=py_0
   - pyzmq=17.1.2=py36hae99301_0
   - readline=7.0=haf1bffa_1
   - send2trash=1.5.0=py_0
-  - service_identity=17.0.0=py_0
   - setuptools=40.2.0=py36_0
   - simplegeneric=0.8.1=py_1
   - six=1.11.0=py36_1
@@ -79,7 +62,6 @@ dependencies:
   - tk=8.6.8=0
   - tornado=4.5.3=py36_0
   - traitlets=4.3.2=py36_0
-  - twisted=18.7.0=py36h470a237_1
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.31.1=py36_1
@@ -87,7 +69,6 @@ dependencies:
   - xz=5.2.4=h470a237_1
   - zeromq=4.2.5=hfc679d8_5
   - zlib=1.2.11=h470a237_3
-  - zope.interface=4.5.0=py36h470a237_1
   - pip:
     - nteract-on-jupyter==1.9.6
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
-# AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-09-17 08:36:41 UTC
+# AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
+# Frozen on 2018-09-17 08:29:40 UTC
 name: r2d
 channels:
   - conda-forge
@@ -10,66 +10,65 @@ dependencies:
   - bleach=2.1.4=py_1
   - bzip2=1.0.6=h470a237_2
   - ca-certificates=2018.8.24=ha4d7672_0
-  - certifi=2018.8.24=py36_1
+  - certifi=2018.4.16=py37_0
   - decorator=4.3.0=py_0
-  - defusedxml=0.5.0=py36_0
-  - entrypoints=0.2.3=py36_2
+  - entrypoints=0.2.3=py37_2
   - gmp=6.1.2=hfc679d8_0
   - html5lib=1.0.1=py_0
-  - ipykernel=4.9.0=py36_0
-  - ipython=6.5.0=py36_0
+  - ipykernel=4.8.2=py37_0
+  - ipython=6.5.0=py37_0
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.2.1=py36_1
-  - jedi=0.12.1=py36_0
+  - jedi=0.12.1=py37_0
   - jinja2=2.10=py_1
-  - jsonschema=2.6.0=py36_2
+  - jsonschema=2.6.0=py37_2
   - jupyter_client=5.2.3=py_1
   - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.34.9=py36_0
   - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
   - libsodium=1.0.16=h470a237_1
   - libstdcxx-ng=7.2.0=hdf63c60_3
-  - markupsafe=1.0=py36h470a237_1
-  - mistune=0.8.3=py36h470a237_2
+  - markupsafe=1.0=py37h470a237_1
+  - mistune=0.8.3=py_0
   - nbconvert=5.4.0=1
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_1
-  - notebook=5.6.0=py36_1
+  - notebook=5.6.0=py37_1
   - openssl=1.0.2p=h470a237_0
   - pandoc=1.19.2=0
   - pandocfilters=1.4.2=py_1
   - parso=0.3.1=py_0
-  - pexpect=4.6.0=py36_0
-  - pickleshare=0.7.4=py36_0
-  - pip=18.0=py36_1
+  - pexpect=4.6.0=py37_0
+  - pickleshare=0.7.4=py37_0
+  - pip=18.0=py37_1
   - prometheus_client=0.3.1=py_1
   - prompt_toolkit=1.0.15=py_1
-  - ptyprocess=0.6.0=py36_0
+  - ptyprocess=0.6.0=py37_0
   - pygments=2.2.0=py_1
-  - python=3.6.6=h5001a0f_0
+  - python=3.7.0=h5001a0f_1
   - python-dateutil=2.7.3=py_0
-  - pyzmq=17.1.2=py36hae99301_0
+  - pyzmq=17.1.2=py37hae99301_0
   - readline=7.0=haf1bffa_1
   - send2trash=1.5.0=py_0
-  - setuptools=40.2.0=py36_0
+  - setuptools=40.2.0=py37_0
   - simplegeneric=0.8.1=py_1
-  - six=1.11.0=py36_1
+  - six=1.11.0=py37_1
   - sqlite=3.24.0=h2f33b56_1
-  - terminado=0.8.1=py36_1
-  - testpath=0.3.1=py36_1
+  - terminado=0.8.1=py37_1
+  - testpath=0.3.1=py37_1
   - tk=8.6.8=0
-  - tornado=4.5.3=py36_0
-  - traitlets=4.3.2=py36_0
+  - traitlets=4.3.2=py37_0
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
-  - wheel=0.31.1=py36_1
-  - widgetsnbextension=3.2.1=py36_1
+  - wheel=0.31.1=py37_1
+  - widgetsnbextension=3.4.1=py37_0
   - xz=5.2.4=h470a237_1
   - zeromq=4.2.5=hfc679d8_5
   - zlib=1.2.11=h470a237_3
+  - defusedxml=0.5.0=py37_1
+  - ipywidgets=7.2.1=py37_0
+  - jupyterlab=0.34.9=py37_0
+  - tornado=4.5.3=py37_0
   - pip:
     - nteract-on-jupyter==1.9.6
 prefix: /opt/conda/envs/r2d
-

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,0 +1,11 @@
+# AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
+# Generated on 2018-09-17 08:29:40 UTC
+dependencies:
+- python=3.7.*
+- ipywidgets==7.2.1
+- jupyterlab==0.34.9
+- nbconvert==5.4.0
+- tornado==4.5.3
+- notebook==5.6.0
+- pip:
+  - nteract_on_jupyter==1.9.6

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -2,6 +2,7 @@ dependencies:
   - python=3.6.*
   - ipywidgets==7.2.1
   - jupyterlab==0.34.9
+  - nbconvert==5.4.0
   - tornado==4.5.3
   - notebook==5.6.0
   - pip:

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
   - python=3.6.*
   - ipywidgets==7.2.1
-  - jupyterlab==0.34.0
+  - jupyterlab==0.34.9
   - tornado==4.5.3
   - notebook==5.6.0
   - pip:

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -100,7 +100,7 @@ def set_python(py_env_file, py):
 
 if __name__ == '__main__':
     # allow specifying which Pythons to update on argv
-    pys = sys.argv[1:] or ('2.7', '3.5', '3.6')
+    pys = sys.argv[1:] or ('2.7', '3.7', '3.5', '3.6')
     for py in pys:
         env_file = ENV_FILE_T.format(py=py)
         set_python(env_file, py)

--- a/tests/conda/py37/environment.yml
+++ b/tests/conda/py37/environment.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - python=3.7

--- a/tests/conda/py37/verify
+++ b/tests/conda/py37/verify
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import sys
+
+assert sys.version_info[:2] == (3, 7), sys.version


### PR DESCRIPTION
- bump jupyterlab to a version packaged on py37 (this is the main change that's required)
- add 3.7 to freeze list
- specify nbconvert 5.4 to avoid falling back to 5.3 in order to get pandoc 2.x (which doesn't work)


cc @allisons who reported Python 3.7 not working on the jupyterhub/binder gitter