### PR TITLE
Subdirectory support

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -663,7 +663,13 @@ class Repo2Docker(Application):
             if self.repo_type == 'remote':
                 self.fetch(self.repo, self.ref, checkout_path)
 
-            os.chdir(os.path.join(checkout_path, self.subdir).rstrip('/'))
+            if self.subdir:
+                checkout_path = os.path.join(checkout_path, self.subdir).rstrip('/')
+                if not os.path.exists(checkout_path):
+                    self.log.error('Subdirectory %s does not exist', self.subdir, extra=dict(phase='failure'))
+                    sys.exit(1)
+
+            os.chdir(checkout_path)
 
             for BP in self.buildpacks:
                 bp = BP()

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -62,6 +62,16 @@ class Repo2Docker(Application):
         """
     )
 
+    subdir = Unicode(
+        '',
+        config=True,
+        help="""
+        Subdirectory of the git repository to examine.
+
+        Defaults to ''.
+        """
+    )
+
     buildpacks = List(
         [
             LegacyBinderDockerBuildPack,
@@ -346,6 +356,12 @@ class Repo2Docker(Application):
         )
 
         argparser.add_argument(
+            '--subdir',
+            type=str,
+            help=self.traits()['subdir'].help,
+        )
+
+        argparser.add_argument(
             '--version',
             dest='version',
             action='store_true',
@@ -481,6 +497,9 @@ class Repo2Docker(Application):
             print('To specify environment variables, you also need to run '
                   'the container')
             sys.exit(1)
+
+        if args.subdir:
+            self.subdir = args.subdir
 
         self.environment = args.environment
 
@@ -644,7 +663,7 @@ class Repo2Docker(Application):
             if self.repo_type == 'remote':
                 self.fetch(self.repo, self.ref, checkout_path)
 
-            os.chdir(checkout_path)
+            os.chdir(os.path.join(checkout_path, self.subdir).rstrip('/'))
 
             for BP in self.buildpacks:
                 bp = BP()


### PR DESCRIPTION
This adds support for creating a Docker image from a subdirectory of a Git repo, rather than just the root.

I wanted to store my Docker image definition and some other configuration in the same repo, without the configuration getting into my image. This seemed like the most straight-forward way to do that.