### PR TITLE
Adjust css for header links

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -5,3 +5,7 @@ img.logo {
 div.body p.caption {
     font-size: 1.5em;
 }
+
+h2 a.toc-backref {
+	text-decoration: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ source_parsers = {
 }
 
 def setup(app):
-    app.add_stylesheet('_static/custom.css')  # may also be an URL
+    app.add_stylesheet('custom.css')  # may also be a URL
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
This removes underlines from H2 headers that are links, and feel obnoxiously out of fashion with other headers.

It is mainly a suggestion, to scratch an itch of mine on the [configuration page](https://repo2docker.readthedocs.io/en/latest/config_files.html#id5). 

The `contents::` directive seems a bit out-of-sync with the `toctree::`, since the latter doesn't let headers link back (admittedly, that is not necessary, since that would be to the navigation bar, which is already there).
