### PR TITLE
[MRG] Only check beginning of name of Python shared library

### DIFF
--- a/tests/julia/pyplot/verify
+++ b/tests/julia/pyplot/verify
@@ -2,7 +2,7 @@
 using PyPlot
 
 # Make sure we are re-using the same conda python
-if PyCall.libpython != "/srv/conda/lib/libpython3.6m"
+if ! startswith(PyCall.libpython, ENV["NB_PYTHON_PREFIX"] * "/lib")
     println("Not re-using conda python! Using " * PyCall.libpython * " instead")
     exit(1)
 end
@@ -16,4 +16,3 @@ if isfile("graph.png")
 else
     exit(1)
 end
-


### PR DESCRIPTION
Only uses the beginning of the string to determine which version of
Python we use in Julia.

In recent builds the Julia tests fail because they use the full path to the Python shared library to determine where Python is coming from. Recently that path has become `/srv/conda/lib/libpython3.6m.so.1.0 ` which fails the strict equality test. Instead we now only check for the beginning of the path.