### PR TITLE
Fix ordering of parameter before URL

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -61,7 +61,7 @@ Building a specific branch / commit / tag
 To build a particular branch and commit, use the argument ``--ref`` and
 specify the ``branch-name`` or ``commit-hash``. For example::
 
-  jupyter-repo2docker https://github.com/norvig/pytudes --ref 9ced85dd9a84859d0767369e58f33912a214a3cf
+  jupyter-repo2docker --ref 9ced85dd9a84859d0767369e58f33912a214a3cf https://github.com/norvig/pytudes
 
 .. tip::
    For reproducible research, we recommend specifying a commit-hash to


### PR DESCRIPTION
Hi, I ran into
`jupyter-repo2docker https://github.com/.../ --ref 16c6b...f1a9f` still using master and ignoring my `--ref`. 
@betatim suggested https://gitter.im/jupyterhub/binder?at=5bc05a19c7bf7c3662f9e0bf to 
```
have you tried changing the order of the arguments repo2docker --ref 16c...1a9f https://github.com/... we've had issues with the arguments after the URL being interpreted as the command to run in the container
```
which indeed fixed the issue. I am here updating the usage.rst document, where I got the ordering from. Not sure if that is the only documentation showing this order, and also not fixing the issue mentioned by Tim. Yours, Steffen