### PR TITLE
Correct url of Advanced Binder Documentation link

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -177,5 +177,5 @@ With Dockerfiles, a regular Docker build will be performed.
 .. note::
     If a Dockerfile is present, all other configuration files will be ignored.
 
-See the `Advanced Binder Documentation <https://mybinder.readthedocs.io/en/latest/dockerfile.html>`_ for
+See the `Advanced Binder Documentation <https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html>`_ for
 best-practices with Dockerfiles.


### PR DESCRIPTION
This fixes a broken link. The URL was missing a "/tutorials/" in the path so it goes from

```diff
$ git diff HEAD^
diff --git a/docs/source/config_files.rst b/docs/source/config_files.rst
index bcaa64a..fe3fb02 100644
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -177,5 +177,5 @@ With Dockerfiles, a regular Docker build will be performed.
 .. note::
     If a Dockerfile is present, all other configuration files will be ignored.
 
-See the `Advanced Binder Documentation <https://mybinder.readthedocs.io/en/latest/dockerfile.html>`_ for
+See the `Advanced Binder Documentation <https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html>`_ for
```