### PR TITLE
be more specific about specifying branches

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,9 +59,10 @@ Building a specific branch / commit / tag
 =========================================
 
 To build a particular branch and commit, use the argument ``--ref`` and
-specify the ``branch-name`` or ``commit-hash``. For example::
+specify the ``branch-name`` (use the full remote name) or ``commit-hash``. For example::
 
   jupyter-repo2docker --ref 9ced85dd9a84859d0767369e58f33912a214a3cf https://github.com/norvig/pytudes
+  jupyter-repo2docker --ref origin/master https://github.com/norvig/pytudes
 
 .. tip::
    For reproducible research, we recommend specifying a commit-hash to


### PR DESCRIPTION
People are not used to including origin/ when asking for a branch-name,
see also https://github.com/jupyter/repo2docker/issues/135#issuecomment-343556938
so add that to the examples here.