### PR TITLE
adding symlink to roadmap in root

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,1 @@
+docs/source/contributing/roadmap.md


### PR DESCRIPTION
This adds a symlink to the roadmap doc in the root of the repository, since people often look for it there (particularly more developer-types)