### PR TITLE
Ensure Python3 before reading README with encoding arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 from setuptools import setup, find_packages
+import sys
 import versioneer
 
-import sys
 if sys.version_info[0] < 3:
-    sys.stderr.write('jupyter-repo2docker requires Python 3 but the running Python is %s.%s.%s' % sys.version_info[:3])
-    sys.exit(1)
-
-with open('README.md', encoding="utf8") as f:
-    readme = f.read()
+    readme = None
+else:
+    with open('README.md', encoding="utf8") as f:
+        readme = f.read()
 
 setup(
     name='jupyter-repo2docker',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 import versioneer
 
+import sys
+if sys.version_info[0] < 3:
+    sys.stderr.write('jupyter-repo2docker requires Python 3 but the running Python is %s.%s.%s' % sys.version_info[:3])
+    sys.exit(1)
 
 with open('README.md', encoding="utf8") as f:
     readme = f.read()


### PR DESCRIPTION
If you accidentally try to install using Python 2 you get this error:

```python
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/nokome/nokome/repo2docker/setup.py", line 5, in <module>
        with open('README.md', encoding="utf8") as f:
    TypeError: 'encoding' is an invalid keyword argument for this function
```
Ideally, the user would be asked to use Python 3. If you remove the `encoding` argument, and try again then `pip` gives us this, more informative message:

```bash
$ python -m pip install -e .
Obtaining file:///home/nokome/nokome/repo2docker
jupyter-repo2docker requires Python '>=3.4' but the running Python is 2.7.12
```

This little PR implements a similar behaviour, whilst also reading the README using the correct encoding.