### PR TITLE
Make apt be quieter

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -16,10 +16,10 @@ FROM buildpack-deps:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set up locales properly
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends locales && \
-    apt-get purge && \
-    apt-get clean && \
+RUN apt-get update -qq && \
+    apt-get install -qq --yes --no-install-recommends locales && \
+    apt-get purge -qq && \
+    apt-get clean -qq && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
@@ -49,23 +49,26 @@ RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  ap
     echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
     echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
+# Base package installs are not super interesting to users, so hide their outputs
+# If install fails for some reason, errors will still be printed
+RUN apt-get update -qq && \
+    apt-get install -qq --yes --no-install-recommends \
        {% for package in base_packages -%}
        {{ package }} \
        {% endfor -%}
-    && apt-get purge && \
-    apt-get clean && \
+    && apt-get purge -qq && \
+    apt-get clean -qq && \
     rm -rf /var/lib/apt/lists/*
 
+# This apt-get install is *not* quiet, so users see their packages being installed
 {% if packages -%}
-RUN apt-get update && \
+RUN apt-get update -qq && \
     apt-get install --yes \
        {% for package in packages -%}
        {{ package }} \
        {% endfor -%}
-    && apt-get purge && \
-    apt-get clean && \
+    && apt-get purge -qq && \
+    apt-get clean -qq && \
     rm -rf /var/lib/apt/lists/*
 {% endif -%}
 


### PR DESCRIPTION
Currently a *lot* of our log info is from apt packages being
installed, and package lists being updated. This is mostly not
very useful information to users. The following outputs are
hidden:

- apt-get update, purge & clean
- apt-get installs for base packages

When there is any error from any of the apt-get steps, they will
be printed. Any packages the user explicitly lists (via apt.txt)
will have their install status messages output.