### PR TITLE
Log a 'success' message when push is complete

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -566,6 +566,7 @@ class Repo2Docker(Application):
                 self.log.info('Pushing image\n',
                               extra=dict(progress=layers, phase='pushing'))
                 last_emit_time = time.time()
+        self.log.info(f'Successfully pushed {self.output_image_spec}', extra=dict(phase='pushing'))
 
     def run_image(self):
         """Run docker container from built image


### PR DESCRIPTION
Otherwise there's no useful info printed on completion when 
you are pushing from a local install.