### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment:
+  layout: header, changes, diff
+coverage:
+  status:
+    patch:
+      default:
+        target: '20'
+    project:
+      default:
+        target: auto


### PR DESCRIPTION
This adds a codecov config that requires PRs to have a minimal amount of coverage for their diff.

We are currently at 75% coverage which is pretty low. Having an automated reminder like this should help us add tests for new PRs to see if we can increase overall coverage. At least it won't go down :)

Should check that this doesn't lead to the bot commenting on each PR as that causes a lot of noise. The goal is to have an extra check where we see the travis result.