### PR TITLE
push tagged images on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
       provider: script
       script: "./travis/travis-script.bash"
       on:
+        tags: true
         branch: master
 env:
   matrix:

--- a/travis/travis-script.bash
+++ b/travis/travis-script.bash
@@ -10,4 +10,11 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     docker login -u ${DOCKER_LOGIN} -p "${DOCKER_PASSWORD}"
     docker push ${IMAGE}
     echo "Pushed new repo2docker image: ${IMAGE}"
+    if [[ ! -z "${TRAVIS_TAG}" ]]; then
+        # also push tagged versions
+        IMAGE_TAG="jupyter/repo2docker:${TRAVIS_TAG/v/}"
+        docker tag "${IMAGE}" "${IMAGE_TAG}"
+        docker push "${IMAGE_TAG}"
+        echo "Pushed new repo2docker image: ${IMAGE_TAG}"
+    fi
 fi


### PR DESCRIPTION
creates jupyter/repo2docker:0.7.0 when we release 0.7.0

we have to manually tag images for past releases