### PR TITLE
fix push-tags condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,15 @@ jobs:
   include:
   - stage: deploy
     script: skip
-    if: type = push
+    if: type = push AND (branch = master OR tag IS present)
     env:
     - REPO_TYPE=
     deploy:
       provider: script
       script: "./travis/travis-script.bash"
       on:
-        tags: true
-        branch: master
+        repo: jupyter/repo2docker
+
 env:
   matrix:
   - REPO_TYPE=base


### PR DESCRIPTION
it should build master and tags on this repo. #499 wasn't quite right.

`on` conditions only fire when they are *all* met, which was it's a tag *and* it's the master branch, which is never true. Use `if` instead for a proper boolean condition.