### PR TITLE
Copy repo to ${REPO_DIR} rather than ${HOME}

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -169,6 +169,11 @@ def get_argparser():
     )
 
     argparser.add_argument(
+        '--repo-path',
+        help=Repo2Docker.repo_path.help
+    )
+
+    argparser.add_argument(
         '--appendix',
         type=str,
         #help=self.traits()['appendix'].help,
@@ -315,6 +320,9 @@ def make_r2d(argv=None):
         r2d.cleanup_checkout = False
     else:
         r2d.cleanup_checkout = args.clean
+
+    if args.repo_path:
+        r2d.repo_path = args.repo_path
 
     return r2d
 

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -169,8 +169,8 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        '--repo-path',
-        help=Repo2Docker.repo_path.help
+        '--target-repo-dir',
+        help=Repo2Docker.target_repo_dir.help
     )
 
     argparser.add_argument(
@@ -321,8 +321,8 @@ def make_r2d(argv=None):
     else:
         r2d.cleanup_checkout = args.clean
 
-    if args.repo_path:
-        r2d.repo_path = args.repo_path
+    if args.target_repo_dir:
+        r2d.target_repo_dir = args.target_repo_dir
 
     return r2d
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -327,7 +327,7 @@ class Repo2Docker(Application):
         config=True
     )
 
-    repo_path = Unicode(
+    target_repo_dir = Unicode(
         '',
         help="""
         Path inside the image where contents of the repositories are copied to.
@@ -605,8 +605,8 @@ class Repo2Docker(Application):
                         'NB_USER': self.user_name,
                         'NB_UID': str(self.user_id),
                     }
-                    if self.repo_path:
-                        build_args['REPO_PATH'] = self.repo_path
+                    if self.target_repo_dir:
+                        build_args['REPO_DIR'] = self.target_repo_dir
                     self.log.info('Using %s builder\n', bp.__class__.__name__,
                                   extra=dict(phase='building'))
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -328,11 +328,11 @@ class Repo2Docker(Application):
     )
 
     repo_path = Unicode(
-        '$HOME',
+        '',
         help="""
         Path inside the image where contents of the repositories are copied to.
 
-        Build arguments in this are expanded.
+        Defaults to ${HOME} if not set
         """,
         config=True
     )
@@ -604,8 +604,9 @@ class Repo2Docker(Application):
                     build_args = {
                         'NB_USER': self.user_name,
                         'NB_UID': str(self.user_id),
-                        'REPO_PATH': self.repo_path
                     }
+                    if self.repo_path:
+                        build_args['REPO_PATH'] = self.repo_path
                     self.log.info('Using %s builder\n', bp.__class__.__name__,
                                   extra=dict(phase='building'))
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -617,7 +617,7 @@ class Repo2Docker(Application):
                                           extra=dict(phase='building'))
                         elif 'error' in l:
                             self.log.info(l['error'], extra=dict(phase='failure'))
-                            raise docker.errors.BuildError(l['error'])
+                            raise docker.errors.BuildError(l['error'], build_log='')
                         elif 'status' in l:
                                 self.log.info('Fetching base image...\r',
                                               extra=dict(phase='building'))

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -327,6 +327,16 @@ class Repo2Docker(Application):
         config=True
     )
 
+    repo_path = Unicode(
+        '$HOME',
+        help="""
+        Path inside the image where contents of the repositories are copied to.
+
+        Build arguments in this are expanded.
+        """,
+        config=True
+    )
+
     def fetch(self, url, ref, checkout_path):
         """Fetch the contents of `url` and place it in `checkout_path`.
 
@@ -593,7 +603,8 @@ class Repo2Docker(Application):
                 if not self.dry_run:
                     build_args = {
                         'NB_USER': self.user_name,
-                        'NB_UID': str(self.user_id)
+                        'NB_UID': str(self.user_id),
+                        'REPO_PATH': self.repo_path
                     }
                     self.log.info('Using %s builder\n', bp.__class__.__name__,
                                   extra=dict(phase='building'))

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -102,6 +102,16 @@ ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
 WORKDIR ${REPO_DIR}
 
+# We want to allow two things:
+#   1. If there's a .local/bin directory in the repo, things there
+#      should automatically be in path
+#   2. postBuild and users should be able to install things into ~/.local/bin
+#      and have them be automatically in path
+#
+# The XDG standard suggests ~/.local/bin as the path for local user-specific
+# installs. See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ENV PATH ${HOME}/.local/bin:${REPO_DIR}/.local/bin:${PATH}
+
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!
 USER root
@@ -243,10 +253,7 @@ class BuildPack:
         Just sets the PATH environment variable. Separated out since
         it is very commonly set by various buildpacks.
         """
-        # Allow local user installs into ~/.local, which is where the
-        # XDG desktop standard suggests these should be
-        # See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-        return ['$HOME/.local/bin']
+        return []
 
     def get_labels(self):
         """

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -38,11 +38,15 @@ ARG NB_UID
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
+# Allow target path repo is cloned to be configurable
+ARG REPO_PATH=${HOME}
+ENV REPO_PATH ${REPO_PATH}
+
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
-WORKDIR ${HOME}
+WORKDIR ${REPO_PATH}
 
 RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
     DISTRO="bionic" && \
@@ -101,8 +105,8 @@ COPY {{ src }} {{ dst }}
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!
 USER root
-COPY src/ ${HOME}
-RUN chown -R ${NB_USER}:${NB_USER} ${HOME}
+COPY src/ ${REPO_PATH}
+RUN chown -R ${NB_USER}:${NB_USER} ${REPO_PATH}
 
 {% if env -%}
 # The rest of the environment
@@ -525,7 +529,7 @@ class BaseImage(BuildPack):
 
             archive_dir, archive = os.path.split(self.stencila_manifest_dir)
             env.extend([
-                ("STENCILA_ARCHIVE_DIR", "${HOME}/" + archive_dir),
+                ("STENCILA_ARCHIVE_DIR", "${REPO_PATH}/" + archive_dir),
                 ("STENCILA_ARCHIVE", archive),
             ])
         return env

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -98,15 +98,15 @@ COPY {{ src }} {{ dst }}
 {% endfor %}
 
 # Allow target path repo is cloned to be configurable
-ARG REPO_PATH=${HOME}
-ENV REPO_PATH ${REPO_PATH}
-WORKDIR ${REPO_PATH}
+ARG REPO_DIR=${HOME}
+ENV REPO_DIR ${REPO_DIR}
+WORKDIR ${REPO_DIR}
 
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!
 USER root
-COPY src/ ${REPO_PATH}
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_PATH}
+COPY src/ ${REPO_DIR}
+RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 {% if env -%}
 # The rest of the environment
@@ -529,7 +529,7 @@ class BaseImage(BuildPack):
 
             archive_dir, archive = os.path.split(self.stencila_manifest_dir)
             env.extend([
-                ("STENCILA_ARCHIVE_DIR", "${REPO_PATH}/" + archive_dir),
+                ("STENCILA_ARCHIVE_DIR", "${REPO_DIR}/" + archive_dir),
                 ("STENCILA_ARCHIVE", archive),
             ])
         return env

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -38,15 +38,10 @@ ARG NB_UID
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
-# Allow target path repo is cloned to be configurable
-ARG REPO_PATH=${HOME}
-ENV REPO_PATH ${REPO_PATH}
-
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
-WORKDIR ${REPO_PATH}
 
 RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
     DISTRO="bionic" && \
@@ -101,6 +96,11 @@ COPY {{ src }} {{ dst }}
 {% for sd in build_script_directives -%}
 {{sd}}
 {% endfor %}
+
+# Allow target path repo is cloned to be configurable
+ARG REPO_PATH=${HOME}
+ENV REPO_PATH ${REPO_PATH}
+WORKDIR ${REPO_PATH}
 
 # Copy and chown stuff. This doubles the size of the repo, because
 # you can't actually copy as USER, only as root! Thanks, Docker!

--- a/repo2docker/buildpacks/nix/install-nix.bash
+++ b/repo2docker/buildpacks/nix/install-nix.bash
@@ -5,6 +5,8 @@ set -ex
 NIX_VERSION="2.1.1"
 NIX_SHA256="ad10b4da69035a585fe89d7330037c4a5d867a372bb0e52a1542ab95aec67999"
 
+# Do all our operations in /tmp, since we can't rely on current directory being writeable yet.
+cd /tmp
 wget --quiet https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.bz2
 echo "$NIX_SHA256  nix-2.1.1-x86_64-linux.tar.bz2" | sha256sum -c
 tar xjf nix-*-x86_64-linux.tar.bz2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,20 +103,26 @@ class Repo2DockerTest(pytest.Function):
 
 class LocalRepo(pytest.File):
     def collect(self):
+        args = [
+            '--appendix', 'RUN echo "appendix" > /tmp/appendix',
+        ]
+        # If there's an extra-args.yaml file in a test dir, assume it contains
+        # a yaml list with extra arguments to be passed to repo2docker
+        extra_args_path = os.path.join(self.fspath.dirname, 'extra-args.yaml')
+        if os.path.exists(extra_args_path):
+            with open(extra_args_path) as f:
+                extra_args = yaml.safe_load(f)
+            args += extra_args
+
+        args.append(self.fspath.dirname)
+
         yield Repo2DockerTest(
             'build', self,
-            args=[
-                '--appendix', 'RUN echo "appendix" > /tmp/appendix',
-                self.fspath.dirname,
-            ],
+            args=args
         )
         yield Repo2DockerTest(
             self.fspath.basename, self,
-            args=[
-                '--appendix', 'RUN echo "appendix" > /tmp/appendix',
-                self.fspath.dirname,
-                './verify',
-            ],
+            args=args + ['./verify']
         )
 
 

--- a/tests/venv/repo-path/README.rst
+++ b/tests/venv/repo-path/README.rst
@@ -1,0 +1,8 @@
+Python - Custom Repository Location
+-----------------------------------
+
+We want to support custom paths where repositories can be
+copied to, instead of ${HOME}. The `extra-args.yaml` file in
+each dir can contain a list of arguments that are passed
+to repo2docker during the test. We copy this repo to
+/srv/repo instead of ${HOME}

--- a/tests/venv/repo-path/extra-args.yaml
+++ b/tests/venv/repo-path/extra-args.yaml
@@ -1,0 +1,2 @@
+- --repo-path
+- /srv/repo

--- a/tests/venv/repo-path/extra-args.yaml
+++ b/tests/venv/repo-path/extra-args.yaml
@@ -1,2 +1,2 @@
-- --repo-path
+- --target-repo-dir
 - /srv/repo

--- a/tests/venv/repo-path/verify
+++ b/tests/venv/repo-path/verify
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import sys
+import os
+
+# Python should still be in /srv/conda
+assert sys.executable == '/srv/conda/bin/python'
+
+# Repo should be in /srv/repo
+assert os.path.exists('/srv/repo/verify')
+assert os.path.abspath(__file__) == '/srv/repo/verify'

--- a/tests/venv/usr-bin/verify
+++ b/tests/venv/usr-bin/verify
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-# Verify that ~/.local/bin is on the PATH
+# Verify that ~/.local/bin & REPO_DIR/.local/bin is on the PATH
 import os
 
 assert os.path.expanduser('~/.local/bin') in os.getenv("PATH"), os.getenv("PATH")
+assert os.getcwd() == os.environ['REPO_DIR']
+assert '{}/.local/bin'.format(os.environ['REPO_DIR']) in os.getenv('PATH')


### PR DESCRIPTION
We want to put the repo somewhere other than ${HOME}
so we can mount persistent storage in ${HOME} more easily.
Most of repo2docker assumes current directory is where
the contents are, so we should be able to get most of it
working by setting WORKDIR to ${REPO_PATH} and letting
${REPO_PATH} be configurable.

Unclear what to do for plain Dockerfiles, Legacy Dockerfiles &
nix.