### PR TITLE
Fix cache-busting when running tests locally

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -469,8 +469,8 @@ class BuildPack:
             # https://github.com/docker/docker-py/pull/1582 is related
             tar.uname = ''
             tar.gname = ''
-            tar.uid = 1000
-            tar.gid = 1000
+            tar.uid = int(build_args.get('NB_UID', 1000))
+            tar.gid = int(build_args.get('NB_UID', 1000))
             return tar
 
         for src in sorted(self.get_build_script_files()):


### PR DESCRIPTION
When you run repo2docker locally, the uid is usually set
to the current user's uid. However, when we push the content
to Docker, we invariably set the uid of the scripts we
use as part of repo2docker at 1000. This causes a cache bust
every time.

This patch uses the correct uid, and fixes cache busting. Makes
local test runs *much* faster.

Fixes #508