### PR TITLE
Run tests concurrently with pytest-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 # Make a wheel and install it to test to catch possible
 # issues with releases
 - pip install --upgrade setuptools pip
-- pip install -r dev-requirements.txt
+- pip install --upgrade -r dev-requirements.txt
 - python setup.py bdist_wheel
 - pip install dist/*.whl
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
 # possible issues with MANIFEST.in
 - pushd tests;
   if [ ${REPO_TYPE} == "r" ] || [ ${REPO_TYPE} == "stencila-r" ] || [ ${REPO_TYPE} == "stencila-py" ]; then
-    travis_wait 30 pytest --cov repo2docker -v ${REPO_TYPE} || exit 1;
+    travis_wait 30 pytest -n auto --cov repo2docker -v ${REPO_TYPE} || exit 1;
   else
-    travis_retry pytest --cov repo2docker -v ${REPO_TYPE} || exit 1;
+    travis_retry pytest -n auto --cov repo2docker -v ${REPO_TYPE} || exit 1;
   fi;
   popd;
 - pip install -r docs/doc-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 pytest
 wheel
 pytest-cov
+pytest-xdist


### PR DESCRIPTION
Should help us discover any race conditions in our
tests that prevent them from running concurrently.

Should also speed up tests.