### PR TITLE
Add command line API to docs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 pytest
 wheel
 pytest-cov
+sphinxcontrib-autoprogram

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,9 @@ import recommonmark.parser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks',
+              'sphinxcontrib.autoprogram',
+              ]
 
 extlinks = {
     'issue': ('https://github.com/jupyter/repo2docker/issues/%s', 'Issue #'),

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -107,4 +107,12 @@ be used by docker directly.
 
      jupyter-repo2docker --no-build --debug https://github.com/norvig/pytudes
 
+
+Command line API
+================
+
+.. autoprogram:: repo2docker.__main__:argparser
+  :prog: jupyter-repo2docker
+
+
 .. _Pytudes: https://github.com/norvig/pytudes

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -37,7 +37,9 @@ def validate_image_name(image_name):
 
 def get_argparser():
     """Get arguments that may be used by repo2docker"""
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(
+        description='Fetch a repository and build a container image',
+    )
 
     argparser.add_argument(
         '--config',

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -194,6 +194,8 @@ def get_argparser():
 
     return argparser
 
+argparser = get_argparser()
+
 
 def make_r2d(argv=None):
     if argv is None:


### PR DESCRIPTION
This PR adds command line API documentation for `jupyter-repo2docker` using the `autoprogram` Sphinx extension. There are a few different options outlined in `docs/source/usage.rst` (e.g. `--ref`, `--debug`, and `--no-build`). However, having all the possible command line arguments listed and documented could be useful for users. 