### PR TITLE
Try see if we're running test twice

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,13 +104,6 @@ class Repo2DockerTest(pytest.Function):
 class LocalRepo(pytest.File):
     def collect(self):
         yield Repo2DockerTest(
-            'build', self,
-            args=[
-                '--appendix', 'RUN echo "appendix" > /tmp/appendix',
-                self.fspath.dirname,
-            ],
-        )
-        yield Repo2DockerTest(
             self.fspath.basename, self,
             args=[
                 '--appendix', 'RUN echo "appendix" > /tmp/appendix',


### PR DESCRIPTION
I *think* we run each test twice - once to see
if notebook starts, and once to run ./verify. This 
seems fair enough, but am trying to get travis to tell
me if this is indeed the case.