### PR TITLE
Update RTD to install repo2docker

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,4 +2,5 @@ name: repo2docker
 type: sphinx
 python:
   version: 3
+  setup_py_install: true
 requirements_file: docs/doc-requirements.txt


### PR DESCRIPTION
I saw the current readthedocs [build is failing](https://readthedocs.org/projects/repo2docker/builds/8289685/). Looks like it's due to the changes made in #515. The issue is that `repo2docker` isn't installed in the readthedocs virtualenv where the documentation is being built, so we're getting an `ImportError` when trying to build the command line API documentation:

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/repo2docker/envs/latest/lib/python3.5/site-packages/sphinxcontrib/autoprogram.py", line 120, in import_object
    mod = __import__(module_name)
ImportError: No module named 'repo2docker'
```

After reading through the readthedocs YAML configuration docs, I think we need to set `setup_py_install` to be `true` in `readthedocs.yml` (ref https://docs.readthedocs.io/en/latest/yaml-config.html#python-setup-py-install) to install `repo2docker` and fix the failing build. That's what is done in this PR. 