### PR TITLE
Remove f-strings

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -426,7 +426,8 @@ class Repo2Docker(Application):
                 self.log.info('Pushing image\n',
                               extra=dict(progress=layers, phase='pushing'))
                 last_emit_time = time.time()
-        self.log.info(f'Successfully pushed {self.output_image_spec}', extra=dict(phase='pushing'))
+        self.log.info('Successfully pushed {}'.format(self.output_image_spec),
+                      extra=dict(phase='pushing'))
 
     def run_image(self):
         """Run docker container from built image
@@ -568,7 +569,7 @@ class Repo2Docker(Application):
                 if not os.path.isdir(checkout_path):
                     self.log.error('Subdirectory %s does not exist',
                                    self.subdir, extra=dict(phase='failure'))
-                    raise FileNotFoundError(f'Could not find {checkout_path}')
+                    raise FileNotFoundError('Could not find {}'.format(checkout_path))
 
             with chdir(checkout_path):
                 for BP in self.buildpacks:

--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -38,7 +38,7 @@ class Git(ContentProvider):
             if hash is None:
                 self.log.error('Failed to check out ref %s', ref,
                                extra=dict(phase='failed'))
-                raise ValueError(f'Failed to check out ref {ref}')
+                raise ValueError('Failed to check out ref {}'.format(ref))
             # If the hash is resolved above, we should be able to reset to it
             for line in execute_cmd(['git', 'reset', '--hard', hash],
                                     cwd=output_dir,

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -14,7 +14,7 @@ def test_version(capsys):
     """
     with pytest.raises(SystemExit):
         make_r2d(['--version'])
-    assert capsys.readouterr().out == f"{__version__}\n"
+    assert capsys.readouterr().out == "{}\n".format(__version__)
 
 def test_simple():
     """


### PR DESCRIPTION
This PR removes f-strings from `repo2docker`

There are a few f-strings in the codebase that are causing the RTD build to fail because the docs are currently built with Python 3.5, while f-strings weren't added until 3.6 (ref https://readthedocs.org/projects/repo2docker/builds/8291787/). I was able to reproduce the f-string related `SyntaxError` when building the docs locally on `master` in a Python 3.5 environment. With the changes in this PR, the docs were successfully built locally with Python 3.5.