### PR TITLE
Use conda only to install python

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,86 +1,80 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-12-17 15:24:58 UTC
+# Frozen on 2018-12-18 20:36:31 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - attrs=18.2.0=py_0
-  - backcall=0.1.0=py_0
-  - bleach=3.0.2=py_1
   - ca-certificates=2018.11.29=ha4d7672_0
   - certifi=2018.11.29=py36_1000
-  - decorator=4.3.0=py_0
-  - defusedxml=0.5.0=py_1
-  - entrypoints=0.2.3=py36_1002
-  - gmp=6.1.2=hfc679d8_0
-  - ipykernel=5.1.0=py36h24bf2e0_1001
-  - ipython=7.2.0=py36h24bf2e0_1000
-  - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.2.1=py36_1
-  - jedi=0.13.2=py36_1000
-  - jinja2=2.10=py_1
-  - jsonschema=3.0.0a3=py36_1000
-  - jupyter_client=5.2.4=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.34.9=py36_0
-  - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
-  - libsodium=1.0.16=h470a237_1
   - libstdcxx-ng=7.2.0=hdf63c60_3
-  - markupsafe=1.1.0=py36h470a237_0
-  - mistune=0.8.4=py36h470a237_0
-  - nbconvert=5.4.0=1
-  - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_2
-  - notebook=5.7.4=py36_1000
   - openssl=1.0.2p=h470a237_1
-  - pandoc=1.19.2=0
-  - pandocfilters=1.4.2=py_1
-  - parso=0.3.1=py_0
-  - pexpect=4.6.0=py36_1000
-  - pickleshare=0.7.5=py36_1000
   - pip=18.1=py36_1000
-  - prometheus_client=0.5.0=py_0
-  - prompt_toolkit=2.0.7=py_0
-  - ptyprocess=0.6.0=py36_1000
-  - pygments=2.3.1=py_0
-  - pyrsistent=0.14.7=py36h470a237_0
   - python=3.6.7=h5001a0f_1
-  - python-dateutil=2.7.5=py_0
-  - pyzmq=17.1.2=py36hae99301_1
   - readline=7.0=haf1bffa_1
-  - send2trash=1.5.0=py_0
   - setuptools=40.6.3=py36_0
-  - six=1.12.0=py36_1000
   - sqlite=3.26.0=hb1c47c0_0
-  - terminado=0.8.1=py36_1001
-  - testpath=0.4.2=py36_1000
   - tk=8.6.9=ha92aebf_0
-  - tornado=5.1.1=py36h470a237_0
-  - traitlets=4.3.2=py36_1000
-  - wcwidth=0.1.7=py_1
-  - webencodings=0.5.1=py_1
   - wheel=0.32.3=py36_0
-  - widgetsnbextension=3.2.1=py36_1
   - xz=5.2.4=h470a237_1
-  - zeromq=4.2.5=hfc679d8_6
   - zlib=1.2.11=h470a237_3
   - pip:
     - alembic==1.0.5
     - async-generator==1.10
+    - backcall==0.1.0
+    - bleach==3.0.2
     - chardet==3.0.4
+    - decorator==4.3.0
+    - defusedxml==0.5.0
+    - entrypoints==0.2.3
     - idna==2.8
+    - ipykernel==5.1.0
+    - ipython==7.2.0
+    - ipython-genutils==0.2.0
+    - ipywidgets==7.2.1
+    - jedi==0.13.2
+    - jinja2==2.10
+    - jsonschema==2.6.0
+    - jupyter-client==5.2.4
+    - jupyter-core==4.4.0
     - jupyterhub==0.9.4
+    - jupyterlab==0.34.9
+    - jupyterlab-launcher==0.13.1
     - mako==1.0.7
+    - markupsafe==1.1.0
+    - mistune==0.8.4
+    - nbconvert==5.4.0
+    - nbformat==4.4.0
+    - notebook==5.7.4
     - nteract-on-jupyter==1.9.6
     - pamela==0.3.0
+    - pandocfilters==1.4.2
+    - parso==0.3.1
+    - pexpect==4.6.0
+    - pickleshare==0.7.5
+    - prometheus-client==0.5.0
+    - prompt-toolkit==2.0.7
+    - ptyprocess==0.6.0
+    - pygments==2.3.1
+    - python-dateutil==2.7.5
     - python-editor==1.0.3
     - python-oauth2==1.1.0
+    - pyzmq==17.1.2
     - requests==2.21.0
+    - send2trash==1.5.0
+    - six==1.12.0
     - sqlalchemy==1.2.15
+    - terminado==0.8.1
+    - testpath==0.4.2
+    - tornado==5.1.1
+    - traitlets==4.3.2
     - urllib3==1.24.1
+    - wcwidth==0.1.7
+    - webencodings==0.5.1
+    - widgetsnbextension==3.2.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,53 +1,51 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-12-17 15:21:41 UTC
+# Frozen on 2018-12-18 20:31:49 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - backports=1.0=py_2
-  - backports.shutil_get_terminal_size=1.0.0=py_3
-  - backports_abc=0.5=py_1
   - ca-certificates=2018.11.29=ha4d7672_0
   - certifi=2018.11.29=py27_1000
-  - decorator=4.3.0=py_0
-  - enum34=1.1.6=py27_1001
-  - futures=3.2.0=py27_1000
-  - ipykernel=4.8.2=py27_0
-  - ipython=5.8.0=py27_0
-  - ipython_genutils=0.2.0=py_1
-  - jupyter_client=5.2.4=py_0
-  - jupyter_core=4.4.0=py_0
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
-  - libsodium=1.0.16=h470a237_1
   - libstdcxx-ng=7.2.0=hdf63c60_3
   - ncurses=6.1=hfc679d8_2
   - openssl=1.0.2p=h470a237_1
-  - pathlib2=2.3.3=py27_1000
-  - pexpect=4.6.0=py27_1000
-  - pickleshare=0.7.5=py27_1000
   - pip=18.1=py27_1000
-  - prompt_toolkit=1.0.15=py_1
-  - ptyprocess=0.6.0=py27_1000
-  - pygments=2.3.1=py_0
   - python=2.7.15=h33da82c_6
-  - python-dateutil=2.7.5=py_0
-  - pyzmq=17.1.2=py27hae99301_1
   - readline=7.0=haf1bffa_1
-  - scandir=1.9.0=py27h470a237_0
   - setuptools=40.6.3=py27_0
-  - simplegeneric=0.8.1=py_1
-  - singledispatch=3.4.0.3=py27_1000
-  - six=1.12.0=py27_1000
   - sqlite=3.26.0=hb1c47c0_0
   - tk=8.6.9=ha92aebf_0
-  - tornado=5.1.1=py27h470a237_0
-  - traitlets=4.3.2=py27_1000
-  - wcwidth=0.1.7=py_1
   - wheel=0.32.3=py27_0
-  - zeromq=4.2.5=hfc679d8_6
   - zlib=1.2.11=h470a237_3
+  - pip:
+    - backports-abc==0.5
+    - backports.shutil-get-terminal-size==1.0.0
+    - decorator==4.3.0
+    - enum34==1.1.6
+    - futures==3.2.0
+    - ipykernel==4.8.2
+    - ipython==5.8.0
+    - ipython-genutils==0.2.0
+    - jupyter-client==5.2.4
+    - jupyter-core==4.4.0
+    - pathlib2==2.3.3
+    - pexpect==4.6.0
+    - pickleshare==0.7.5
+    - prompt-toolkit==1.0.15
+    - ptyprocess==0.6.0
+    - pygments==2.3.1
+    - python-dateutil==2.7.5
+    - pyzmq==17.1.2
+    - scandir==1.9.0
+    - simplegeneric==0.8.1
+    - singledispatch==3.4.0.3
+    - six==1.12.0
+    - tornado==5.1.1
+    - traitlets==4.3.2
+    - wcwidth==0.1.7
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.yml
@@ -1,3 +1,4 @@
 dependencies:
 - python=2.7.*
-- ipykernel==4.8.2
+- pip:
+    - ipykernel==4.8.2

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,86 +1,80 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-12-17 15:24:58 UTC
+# Frozen on 2018-12-18 20:36:31 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - attrs=18.2.0=py_0
-  - backcall=0.1.0=py_0
-  - bleach=3.0.2=py_1
   - ca-certificates=2018.11.29=ha4d7672_0
   - certifi=2018.11.29=py36_1000
-  - decorator=4.3.0=py_0
-  - defusedxml=0.5.0=py_1
-  - entrypoints=0.2.3=py36_1002
-  - gmp=6.1.2=hfc679d8_0
-  - ipykernel=5.1.0=py36h24bf2e0_1001
-  - ipython=7.2.0=py36h24bf2e0_1000
-  - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.2.1=py36_1
-  - jedi=0.13.2=py36_1000
-  - jinja2=2.10=py_1
-  - jsonschema=3.0.0a3=py36_1000
-  - jupyter_client=5.2.4=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterlab=0.34.9=py36_0
-  - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
-  - libsodium=1.0.16=h470a237_1
   - libstdcxx-ng=7.2.0=hdf63c60_3
-  - markupsafe=1.1.0=py36h470a237_0
-  - mistune=0.8.4=py36h470a237_0
-  - nbconvert=5.4.0=1
-  - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_2
-  - notebook=5.7.4=py36_1000
   - openssl=1.0.2p=h470a237_1
-  - pandoc=1.19.2=0
-  - pandocfilters=1.4.2=py_1
-  - parso=0.3.1=py_0
-  - pexpect=4.6.0=py36_1000
-  - pickleshare=0.7.5=py36_1000
   - pip=18.1=py36_1000
-  - prometheus_client=0.5.0=py_0
-  - prompt_toolkit=2.0.7=py_0
-  - ptyprocess=0.6.0=py36_1000
-  - pygments=2.3.1=py_0
-  - pyrsistent=0.14.7=py36h470a237_0
   - python=3.6.7=h5001a0f_1
-  - python-dateutil=2.7.5=py_0
-  - pyzmq=17.1.2=py36hae99301_1
   - readline=7.0=haf1bffa_1
-  - send2trash=1.5.0=py_0
   - setuptools=40.6.3=py36_0
-  - six=1.12.0=py36_1000
   - sqlite=3.26.0=hb1c47c0_0
-  - terminado=0.8.1=py36_1001
-  - testpath=0.4.2=py36_1000
   - tk=8.6.9=ha92aebf_0
-  - tornado=5.1.1=py36h470a237_0
-  - traitlets=4.3.2=py36_1000
-  - wcwidth=0.1.7=py_1
-  - webencodings=0.5.1=py_1
   - wheel=0.32.3=py36_0
-  - widgetsnbextension=3.2.1=py36_1
   - xz=5.2.4=h470a237_1
-  - zeromq=4.2.5=hfc679d8_6
   - zlib=1.2.11=h470a237_3
   - pip:
     - alembic==1.0.5
     - async-generator==1.10
+    - backcall==0.1.0
+    - bleach==3.0.2
     - chardet==3.0.4
+    - decorator==4.3.0
+    - defusedxml==0.5.0
+    - entrypoints==0.2.3
     - idna==2.8
+    - ipykernel==5.1.0
+    - ipython==7.2.0
+    - ipython-genutils==0.2.0
+    - ipywidgets==7.2.1
+    - jedi==0.13.2
+    - jinja2==2.10
+    - jsonschema==2.6.0
+    - jupyter-client==5.2.4
+    - jupyter-core==4.4.0
     - jupyterhub==0.9.4
+    - jupyterlab==0.34.9
+    - jupyterlab-launcher==0.13.1
     - mako==1.0.7
+    - markupsafe==1.1.0
+    - mistune==0.8.4
+    - nbconvert==5.4.0
+    - nbformat==4.4.0
+    - notebook==5.7.4
     - nteract-on-jupyter==1.9.6
     - pamela==0.3.0
+    - pandocfilters==1.4.2
+    - parso==0.3.1
+    - pexpect==4.6.0
+    - pickleshare==0.7.5
+    - prometheus-client==0.5.0
+    - prompt-toolkit==2.0.7
+    - ptyprocess==0.6.0
+    - pygments==2.3.1
+    - python-dateutil==2.7.5
     - python-editor==1.0.3
     - python-oauth2==1.1.0
+    - pyzmq==17.1.2
     - requests==2.21.0
+    - send2trash==1.5.0
+    - six==1.12.0
     - sqlalchemy==1.2.15
+    - terminado==0.8.1
+    - testpath==0.4.2
+    - tornado==5.1.1
+    - traitlets==4.3.2
     - urllib3==1.24.1
+    - wcwidth==0.1.7
+    - webencodings==0.5.1
+    - widgetsnbextension==3.2.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,11 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2018-12-17 15:24:58 UTC
+# Generated on 2018-12-18 20:36:31 UTC
 dependencies:
 - python=3.6.*
-- ipywidgets==7.2.1
-- jupyterlab==0.34.9
-- nbconvert==5.4.0
-- notebook==5.7.4
 - pip:
   - nteract_on_jupyter==1.9.6
   - jupyterhub==0.9.4
+  - notebook==5.7.4
+  - nbconvert==5.4.0
+  - jupyterlab==0.34.9
+  - ipywidgets==7.2.1

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,87 +1,81 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2018-12-17 15:22:44 UTC
+# Frozen on 2018-12-18 20:34:02 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - attrs=18.2.0=py_0
-  - backcall=0.1.0=py_0
-  - bleach=3.0.2=py_1
   - bzip2=1.0.6=h470a237_2
   - ca-certificates=2018.11.29=ha4d7672_0
   - certifi=2018.11.29=py37_1000
-  - decorator=4.3.0=py_0
-  - defusedxml=0.5.0=py_1
-  - entrypoints=0.2.3=py37_1002
-  - gmp=6.1.2=hfc679d8_0
-  - ipykernel=5.1.0=py37h24bf2e0_1001
-  - ipython=7.2.0=py37h24bf2e0_1000
-  - ipython_genutils=0.2.0=py_1
-  - jedi=0.13.2=py37_1000
-  - jinja2=2.10=py_1
-  - jsonschema=3.0.0a3=py37_1000
-  - jupyter_client=5.2.4=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterlab_launcher=0.13.1=py_2
   - libffi=3.2.1=hfc679d8_5
   - libgcc-ng=7.2.0=hdf63c60_3
-  - libsodium=1.0.16=h470a237_1
   - libstdcxx-ng=7.2.0=hdf63c60_3
-  - markupsafe=1.1.0=py37h470a237_0
-  - mistune=0.8.4=py37h470a237_0
-  - nbconvert=5.4.0=1
-  - nbformat=4.4.0=py_1
   - ncurses=6.1=hfc679d8_2
-  - notebook=5.7.4=py37_1000
   - openssl=1.0.2p=h470a237_1
-  - pandoc=1.19.2=0
-  - pandocfilters=1.4.2=py_1
-  - parso=0.3.1=py_0
-  - pexpect=4.6.0=py37_1000
-  - pickleshare=0.7.5=py37_1000
   - pip=18.1=py37_1000
-  - prometheus_client=0.5.0=py_0
-  - prompt_toolkit=2.0.7=py_0
-  - ptyprocess=0.6.0=py37_1000
-  - pygments=2.3.1=py_0
-  - pyrsistent=0.14.7=py37h470a237_0
   - python=3.7.1=h5001a0f_0
-  - python-dateutil=2.7.5=py_0
-  - pyzmq=17.1.2=py37hae99301_1
   - readline=7.0=haf1bffa_1
-  - send2trash=1.5.0=py_0
   - setuptools=40.6.3=py37_0
-  - six=1.12.0=py37_1000
   - sqlite=3.26.0=hb1c47c0_0
-  - terminado=0.8.1=py37_1001
-  - testpath=0.4.2=py37_1000
   - tk=8.6.9=ha92aebf_0
-  - tornado=5.1.1=py37h470a237_0
-  - traitlets=4.3.2=py37_1000
-  - wcwidth=0.1.7=py_1
-  - webencodings=0.5.1=py_1
   - wheel=0.32.3=py37_0
-  - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h470a237_1
-  - zeromq=4.2.5=hfc679d8_6
   - zlib=1.2.11=h470a237_3
-  - ipywidgets=7.2.1=py37_0
-  - jupyterlab=0.34.9=py37_0
   - pip:
     - alembic==1.0.5
     - async-generator==1.10
+    - backcall==0.1.0
+    - bleach==3.0.2
     - chardet==3.0.4
+    - decorator==4.3.0
+    - defusedxml==0.5.0
+    - entrypoints==0.2.3
     - idna==2.8
+    - ipykernel==5.1.0
+    - ipython==7.2.0
+    - ipython-genutils==0.2.0
+    - ipywidgets==7.2.1
+    - jedi==0.13.2
+    - jinja2==2.10
+    - jsonschema==2.6.0
+    - jupyter-client==5.2.4
+    - jupyter-core==4.4.0
     - jupyterhub==0.9.4
+    - jupyterlab==0.34.9
+    - jupyterlab-launcher==0.13.1
     - mako==1.0.7
+    - markupsafe==1.1.0
+    - mistune==0.8.4
+    - nbconvert==5.4.0
+    - nbformat==4.4.0
+    - notebook==5.7.4
     - nteract-on-jupyter==1.9.6
     - pamela==0.3.0
+    - pandocfilters==1.4.2
+    - parso==0.3.1
+    - pexpect==4.6.0
+    - pickleshare==0.7.5
+    - prometheus-client==0.5.0
+    - prompt-toolkit==2.0.7
+    - ptyprocess==0.6.0
+    - pygments==2.3.1
+    - python-dateutil==2.7.5
     - python-editor==1.0.3
     - python-oauth2==1.1.0
+    - pyzmq==17.1.2
     - requests==2.21.0
+    - send2trash==1.5.0
+    - six==1.12.0
     - sqlalchemy==1.2.15
+    - terminado==0.8.1
+    - testpath==0.4.2
+    - tornado==5.1.1
+    - traitlets==4.3.2
     - urllib3==1.24.1
+    - wcwidth==0.1.7
+    - webencodings==0.5.1
+    - widgetsnbextension==3.2.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,11 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2018-12-17 15:22:44 UTC
+# Generated on 2018-12-18 20:34:02 UTC
 dependencies:
 - python=3.7.*
-- ipywidgets==7.2.1
-- jupyterlab==0.34.9
-- nbconvert==5.4.0
-- notebook==5.7.4
 - pip:
   - nteract_on_jupyter==1.9.6
   - jupyterhub==0.9.4
+  - notebook==5.7.4
+  - nbconvert==5.4.0
+  - jupyterlab==0.34.9
+  - ipywidgets==7.2.1

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,9 +1,9 @@
 dependencies:
   - python=3.6.*
-  - ipywidgets==7.2.1
-  - jupyterlab==0.34.9
-  - nbconvert==5.4.0
-  - notebook==5.7.4
   - pip:
     - nteract_on_jupyter==1.9.6
     - jupyterhub==0.9.4
+    - notebook==5.7.4
+    - nbconvert==5.4.0
+    - jupyterlab==0.34.9
+    - ipywidgets==7.2.1


### PR DESCRIPTION
Use pip for everything else.

Testing to see if:

- This is faster
- Prevents python downgrades and what not (maybe related to
  https://github.com/jupyter/repo2docker/issues/522)