### PR TITLE
WIP: conda-pack base environments

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -97,6 +97,8 @@ class CondaBuildPack(BaseImage):
         """
         files = {
             'conda/install-miniconda.bash': '/tmp/install-miniconda.bash',
+            # FIXME: hardcoded test
+            'conda/environment.py-3.6.tar.gz': '/tmp/environment.tar.gz',
         }
         py_version = self.python_version
         self.log.info("Building conda environment for python=%s" % py_version)

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -3,49 +3,63 @@
 set -ex
 
 cd $(dirname $0)
-MINICONDA_VERSION=4.5.11
-CONDA_VERSION=4.5.11
-URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
-INSTALLER_PATH=/tmp/miniconda-installer.sh
 
-wget --quiet $URL -O ${INSTALLER_PATH}
-chmod +x ${INSTALLER_PATH}
-
-# Only MD5 checksums are available for miniconda
-# Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="e1045ee415162f944b6aebfe560b8fee"
-
-if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
-    echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
-    exit 1
-fi
-
-bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
+
+if [[ -f /tmp/environment.tar.gz ]]; then
+    UNPACK_ONLY=1
+    # unpack the archived environment
+    # we don't run any install commands here
+    # since everything is already packed up.
+    mkdir -p ${CONDA_DIR}
+    tar -xf /tmp/environment.tar.gz -C ${CONDA_DIR}
+    conda-unpack
+else
+    # install miniconda
+    MINICONDA_VERSION=4.5.11
+    CONDA_VERSION=4.5.11
+    URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
+    INSTALLER_PATH=/tmp/miniconda-installer.sh
+
+    wget --quiet $URL -O ${INSTALLER_PATH}
+    chmod +x ${INSTALLER_PATH}
+
+    # Only MD5 checksums are available for miniconda
+    # Can be obtained from https://repo.continuum.io/miniconda/
+    MD5SUM="e1045ee415162f944b6aebfe560b8fee"
+    if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
+        echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
+        exit 1
+    fi
+    bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+    # Remove the big installer so we don't increase docker image size too much
+    rm ${INSTALLER_PATH}
+    # bug in conda 4.3.>15 prevents --set update_dependencies
+    echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
+fi
 
 # Allow easy direct installs from conda forge
 conda config --system --add channels conda-forge
-
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true
 
-# install conda itself
-conda install -yq conda==${CONDA_VERSION}
+if [[ -z "$UNPACK_ONLY" ]]; then
+    # installing from miniconda not conda-pack,
+    # finish installing the env
+    conda install -yq conda==${CONDA_VERSION}
 
-# switch Python in its own step
-# since switching Python during an env update can
-# prevent pip installation.
-# we wouldn't have this issue if we did `conda env create`
-# instead of `conda env update` in these cases
-conda install -y $(cat /tmp/environment.yml | grep -o '\spython=.*')
+    # switch Python in its own step
+    # since switching Python during an env update can
+    # prevent pip installation.
+    # we wouldn't have this issue if we did `conda env create`
+    # instead of `conda env update` in these cases
+    conda install -y $(cat /tmp/environment.yml | grep -o '\spython=.*')
 
-# bug in conda 4.3.>15 prevents --set update_dependencies
-echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
-
-echo "installing root env:"
-cat /tmp/environment.yml
-conda env update -n root -f /tmp/environment.yml
+    echo "installing root env:"
+    cat /tmp/environment.yml
+    conda env update -n root -f /tmp/environment.yml
+fi
 
 # enable nteract-on-jupyter, which was installed with pip
 jupyter serverextension enable nteract_on_jupyter --sys-prefix
@@ -59,14 +73,12 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
     ${CONDA_DIR}/envs/kernel/bin/ipython kernel install --prefix "${CONDA_DIR}"
     rm -f ${CONDA_DIR}/envs/kernel/conda-meta/history
 fi
+
 # remove conda history file,
 # which seems to result in some effective pinning of packages in the initial env,
 # which we don't intend
 rm -f ${CONDA_DIR}/conda-meta/history
 # Clean things out!
 conda clean -tipsy
-
-# Remove the big installer so we don't increase docker image size too much
-rm ${INSTALLER_PATH}
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}


### PR DESCRIPTION
For the initial environment, installation is slow because we have to do it in stages:

1. install miniconda
2. install chosen python (never the same as miniconda)
3. install base environment (conda packages)
4. install remaining environment (pip packages)

This involves lots of talking to upstream repos and redundancies (e.g. miniconda comes with a Python that we immediately replace, as noted in #522).

This PR adds to our freeze step `conda-pack`, which doesn't just freeze the package specifications, but the package contents themselves. This lets us replace the miniconda install with our own bootstrap of the base env.

Running this on `tests/venv/default` (with docker build cache disabled) takes 2:47 on master and 1:04 on this branch. It might be a little slower if the pack came from a download instead of a local file, since it's a pretty big archive.

The things still to figure out:

- how do we distribute the packs? Is it purely a local optimization for repeated builds or do we require them strictly? If we do it as a runtime cache, including them in the repo2docker image would be easy, but it also means our tests would have a hard time benefiting from the speedup. It also means there's two code paths for initial installation, depending on whether the cache is present or not.
- Is this a good idea at all? Distributing our own binary bundles rather than specs isn't the most in-line with reproducibility. However, it is just zipping up the result of an install step of a strictly frozen env. I'd feel more sanguine about the local cache approach for this reason, but that also means it's going to benefit fewer folks (i.e. mybinder.org users, but few home users).

closes #522 