### PR TITLE
fix commit hash truncation on docker images

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -2,6 +2,6 @@
 
 # when building jupyter/repo2docker:master also push jupyter/repo2docker:abcd1234
 
-HASH_IMAGE="$DOCKER_REPO:${SOURCE_COMMIT:8}"
+HASH_IMAGE="$DOCKER_REPO:${SOURCE_COMMIT: -8}"
 docker tag $DOCKER_REPO:$DOCKER_TAG $HASH_IMAGE
 docker push $HASH_IMAGE


### PR DESCRIPTION
truncate to 8 characters correctly