### PR TITLE
Remove ipyleaflet dependency from test

### DIFF
--- a/tests/venv/start/postBuild/postBuild
+++ b/tests/venv/start/postBuild/postBuild
@@ -2,5 +2,3 @@
 
 # this value should not be visible in `verify`
 export TEST_START_VAR="var is set by postBuild"
-
-jupyter nbextension enable --py --sys-prefix ipyleaflet

--- a/tests/venv/start/postBuild/requirements.txt
+++ b/tests/venv/start/postBuild/requirements.txt
@@ -1,1 +1,0 @@
-ipyleaflet

--- a/tests/venv/start/postBuild/verify
+++ b/tests/venv/start/postBuild/verify
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-jupyter nbextension list | grep 'jupyter-leaflet' | grep enabled
 
 # set value of TEST_START_VAR to empty string when it is not defined
 if [ "${TEST_START_VAR:-}" != "var is set" ]


### PR DESCRIPTION
Not sure it adds anything to the test except more stuff to install which makes the test slower.