### PR TITLE
Ensure git submodules are updated and initialised

### DIFF
--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -45,6 +45,12 @@ class Git(ContentProvider):
                                     capture=yield_output):
                 yield line
 
+        # ensure that git submodules are initialised and updated
+        for line in execute_cmd(['git', 'submodule', 'update', '--init', '--recursive'],
+                                cwd=output_dir,
+                                capture=yield_output):
+            yield line
+
         cmd = ['git', 'rev-parse', 'HEAD']
         sha1 = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=output_dir)
         self._sha1 = sha1.stdout.read().decode().strip()


### PR DESCRIPTION
When obtaining content from a git repository that uses submodules, we need to ensure that the submodules are initialised and updated. It is not enough to just clone with `--recursive` option, because if a ref is also provided, the submodules will need to be updated and potentially initialised *after* checking out the provided ref. This PR adds a command `git submodule update --init --recursive` to resolve this.

I've verified this works with a github repo where the submodules were in a different state in a branch than they were in master. If you'd like some kind of unit test added, happy to add one, but would appreciate some advice on the best approach.

As I've written this, the command `git submodule update --init --recursive` will always be run, regardless of whether a ref was provided. Arguably you could run the command only if a ref was provided as it shouldn't be necessary if no ref was provided, but it seemed harmless and a bit safer to run it always. Happy to change this if you think better to run only if ref is provided.