### PR TITLE
Fixes Travis build errors related to pytest and Sphinx 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,7 +3,7 @@
 # update these accordingly
 
 [dev-packages]
-pytest="*"
+pytest=">=3.6"
 wheel="*"
 pytest-cov="*"
 PyYAML = "*"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Note that there is also a Pipfile for this project if you are updating this 
 # file do not forget to update the Pipfile accordingly
 pyyaml
-pytest
+pytest>=3.6
 wheel
 pytest-cov

--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -10,7 +10,7 @@ repo2docker merged.
   community is a great way to save time later.
 * Make edits in your fork of the repo2docker repository
 * Submit a pull request (this is how all changes are made)
-* Edit [the changelog](./../../changelog.html)
+* Edit [the changelog](./../../changelog)
   by appending your feature / bug fix to the development version.
 * Wait for a community member to merge your changes
 * (optional) Deploy a new version of repo2docker to mybinder.org by [following these steps](http://mybinder-sre.readthedocs.io/en/latest/deployment/how.html)
@@ -31,7 +31,7 @@ to help you make a contribution.
 * describe why you are proposing the changes you are proposing;
 * try to not rush changes (the definition of rush depends on how big your
   changes are);
-* Enter your changes into the [changelog](./../../changelog.html) in `docs/source/changelog.rst`;
+* Enter your changes into the [changelog](./../../changelog) in `docs/source/changelog.rst`;
 * someone else has to merge your PR;
 * new code needs to come with a test;
 * apply [PEP8](https://www.python.org/dev/peps/pep-0008/) as much


### PR DESCRIPTION
Proposed fix for https://github.com/jupyter/repo2docker/issues/548.

I'm not sure that this is the right solution here, but pinning the pytest version does work.  It may make sense to pin to a later version.  

Included a change to fix a Sphinx documentation build error apparently caused by recent changelog changes.