### PR TITLE
Register conda shell integration

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -21,7 +21,7 @@ if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
 fi
 
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
-export PATH="${CONDA_DIR}/bin:$PATH"
+. ${CONDA_DIR}/etc/profile.d/conda.sh
 
 # Allow easy direct installs from conda forge
 conda config --system --add channels conda-forge


### PR DESCRIPTION
This allows current best practice `conda activate <name>` rather than `source activate <name>`.

See https://github.com/conda/conda/blob/master/CHANGELOG.md#440-2017-12-20