### PR TITLE
updating interfaces page and adding jupyterlab workspaces page

### DIFF
--- a/docs/source/howto/lab_workspaces.rst
+++ b/docs/source/howto/lab_workspaces.rst
@@ -14,6 +14,6 @@ another JupyterLab installation in order to share a workspace with
 someone else.
 
 In order to package your workspace with a repository, we recommend
-following the steps at the following example repository:
+following the steps in this example repository:
 
 https://github.com/ian-r-rose/binder-workspace-demo/

--- a/docs/source/howto/lab_workspaces.rst
+++ b/docs/source/howto/lab_workspaces.rst
@@ -1,0 +1,19 @@
+.. howto/lab_workspaces::
+
+=============================================
+Share JupyterLab Workspaces with a repository
+=============================================
+
+JupyterLab uses `workspaces <https://jupyterlab.readthedocs.io/en/stable/user/urls.html#managing-workspaces-ui>`_
+to save the current state of windows, settings, and documents that
+are open in a JupyterLab session. It is a way to persist the general
+configuration over time.
+
+It is possible to export JupyterLab workspaces and load them in to
+another JupyterLab installation in order to share a workspace with
+someone else.
+
+In order to package your workspace with a repository, we recommend
+following the steps at the following example repository:
+
+https://github.com/ian-r-rose/binder-workspace-demo/

--- a/docs/source/howto/user_interface.rst
+++ b/docs/source/howto/user_interface.rst
@@ -39,17 +39,17 @@ To learn more about URLs in JupyterLab and Jupyter Notebook, visit
 `starting JupyterLab <http://jupyterlab.readthedocs.io/en/latest/getting_started/starting.html>`_.
 
 
-Nteract
+nteract
 =======
 
-`Nteract is a notebook interface <https://nteract.io/>`_ built with React.
+`nteract is a notebook interface <https://nteract.io/>`_ built with React.
 It is similar to a more feature-filled version of the traditional
 Jupyter Notebook interface.
 
-Nteract comes pre-installed in any session that has been built from
+nteract comes pre-installed in any session that has been built from
 a Python repository.
 
-You can launch Nteract from within a user
+You can launch nteract from within a user
 session by replacing ``/tree`` with ``/nteract`` at the end of a notebook
 server's URL like so:
 
@@ -59,14 +59,14 @@ server's URL like so:
 
 For example, the following Binder URL will open the
 `pyTudes repository <https://github.com/norvig/pytudes>`_
-and begin an Nteract session in the ``ipynb`` folder:
+and begin an nteract session in the ``ipynb`` folder:
 
 https://mybinder.org/v2/gh/norvig/pytudes/master?urlpath=nteract/tree/ipynb
 
-The ``/tree/ipynb`` above is how Nteract directs you to a specific file
+The ``/tree/ipynb`` above is how nteract directs you to a specific file
 or folder.
 
-To learn more about Nteract, visit `the Nteract website <https://nteract.io/about>`_.
+To learn more about nteract, visit `the nteract website <https://nteract.io/about>`_.
 
 
 RStudio

--- a/docs/source/howto/user_interface.rst
+++ b/docs/source/howto/user_interface.rst
@@ -7,8 +7,9 @@ Configure the user interface
 You can build several user interfaces into the resulting Docker image.
 This is controlled with various :ref:`configuration files <config-files>`.
 
+
 JupyterLab
-----------
+==========
 
 You do not need any extra configuration in order to allow the use
 of the JupyterLab interface. You can launch JupyterLab from within a user
@@ -25,11 +26,51 @@ To switch back to the classic notebook, add ``/tree`` to the URL like so:
 
    http(s)://<server:port>/tree
 
+For example, the following Binder URL will open the
+`pyTudes repository <https://github.com/norvig/pytudes>`_
+and begin a JupyterLab session in the ``ipynb`` folder:
+
+https://mybinder.org/v2/gh/norvig/pytudes/master?urlpath=lab/tree/ipynb
+
+The ``/tree/ipynb`` above is how JupyterLab directs you to a specific file
+or folder.
+
 To learn more about URLs in JupyterLab and Jupyter Notebook, visit
 `starting JupyterLab <http://jupyterlab.readthedocs.io/en/latest/getting_started/starting.html>`_.
 
+
+Nteract
+=======
+
+`Nteract is a notebook interface <https://nteract.io/>`_ built with React.
+It is similar to a more feature-filled version of the traditional
+Jupyter Notebook interface.
+
+Nteract comes pre-installed in any session that has been built from
+a Python repository.
+
+You can launch Nteract from within a user
+session by replacing ``/tree`` with ``/nteract`` at the end of a notebook
+server's URL like so:
+
+.. code-block:: none
+
+   http(s)://<server:port>/nteract
+
+For example, the following Binder URL will open the
+`pyTudes repository <https://github.com/norvig/pytudes>`_
+and begin an Nteract session in the ``ipynb`` folder:
+
+https://mybinder.org/v2/gh/norvig/pytudes/master?urlpath=nteract/tree/ipynb
+
+The ``/tree/ipynb`` above is how Nteract directs you to a specific file
+or folder.
+
+To learn more about Nteract, visit `the Nteract website <https://nteract.io/about>`_.
+
+
 RStudio
--------
+=======
 
 The RStudio user interface is automatically enabled if a configuration file for
 R is detected (i.e. an R version specified in ``runtime.txt``). If this is detected,
@@ -39,10 +80,39 @@ RStudio will be accessible by appending ``/rstudio`` to the URL, like so:
 
    http(s)://<server:port>/rstudio
 
-Stencila
---------
+For example, the following Binder link will open an RStudio session in
+the `R demo repository <https://github.com/binder-examples/r>`_.
 
-The Stencila user interface is automatically enabled if a Stencila document (i.e. 
+http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio
+
+
+Shiny
+=====
+
+`Shiny lets you create interactive visualizaions with R <https://shiny.rstudio.com/>`_.
+Shiny is automatically enabled if a configuration file for
+R is detected (i.e. an R version specified in ``runtime.txt``). If
+this is detected, Shiny will be accessible by appending
+``/shiny/<folder-w-shiny-files>`` to the URL, like so:
+
+.. code-block:: none
+
+   http(s)://<server:port>/shiny/bus-dashboard
+
+This assumes that a folder called ``bus-dashboard`` exists in the root
+of the repository, and that it contains all of the files needed to run
+a Shiny app.
+
+For example, the following Binder link will open a Shiny session in
+the `R demo repository <https://github.com/binder-examples/r>`_.
+
+http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=shiny/bus-dashboard/
+
+
+Stencila
+========
+
+The Stencila user interface is automatically enabled if a Stencila document (i.e.
 a file ``manifest.xml``) is detected. Stencila will be accessible by appending
 ``/stencila`` to the URL, like so:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,11 +24,17 @@ Please report `Bugs <https://github.com/jupyter/repo2docker/issues>`_,
    faq
 
 .. toctree::
-   :maxdepth: 1
-   :caption: How-to...
+   :maxdepth: 2
+   :caption: How-To: User interfaces and environments
 
    howto/user_interface
    howto/languages
+   howto/lab_workspaces
+
+.. toctree::
+   :maxdepth: 2
+   :caption: How-To: Deployment and administration
+
    howto/jupyterhub_images
    howto/deploy
 


### PR DESCRIPTION
This does the following:

* updates the interfaces page to give more useful information.
* Adds a section on Nteract and Shiny
* Adds a page about packaging workspaces for JupyterLab
* Does some minor re-structuring on the index page to make the content more discoverable (trying to riff off of @yuvipanda 's TLJH docs)

If we merge this in, then we should also update `conf.py` in the Binder docs repository to pull the JupyterLab workspaces page into the build: https://github.com/jupyterhub/binder/blob/master/doc/conf.py#L172