### PR TITLE
missing quotes in GIT_CREDENTIAL_ENV

### DIFF
--- a/docker/git-credential-env
+++ b/docker/git-credential-env
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo -e $GIT_CREDENTIAL_ENV
+echo -e "$GIT_CREDENTIAL_ENV"

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -1,0 +1,21 @@
+"""Tests for docker bits"""
+
+import os
+from subprocess import check_output
+
+repo_root = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+
+
+def test_git_credential_env():
+    credential_env = "username=abc\npassword=def"
+    out = (
+        check_output(
+            os.path.join(repo_root, "docker", "git-credential-env"),
+            env={'GIT_CREDENTIAL_ENV': credential_env},
+        )
+        .decode()
+        .strip()
+    )
+    assert out == credential_env


### PR DESCRIPTION
echo without quotes removes newline, echo with quotes preserves it.

Previously failing test added.

I believe this is needed to deploy BinderHub with private credentials (cc @sgibson91 who's looking at this)