### PR TITLE
npm installation

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -356,6 +356,7 @@ class BuildPack:
         You can use environment variable substitutions in both the
         username and the execution script.
         """
+
         return []
 
     def get_assemble_scripts(self):
@@ -520,8 +521,34 @@ class BaseImage(BuildPack):
     def get_build_env(self):
         """Return env directives required for build"""
         return [
-            ("APP_BASE", "/srv")
+            ("APP_BASE", "/srv"),
+            ('NPM_DIR', '${APP_BASE}/npm'),
+            ('NPM_CONFIG_GLOBALCONFIG','${NPM_DIR}/npmrc')
         ]
+
+    def get_path(self):
+        return super().get_path() + [
+            '${NPM_DIR}/bin'
+        ]
+
+    def get_build_scripts(self):
+        scripts = [
+            (
+                "root",
+                r"""
+                mkdir -p ${NPM_DIR} && \
+                chown -R ${NB_USER}:${NB_USER} ${NPM_DIR}
+                """
+            ),
+            (
+                "${NB_USER}",
+                r"""
+                npm config --global set prefix ${NPM_DIR}
+                """
+                ),
+        ]
+
+        return super().get_build_scripts() + scripts
 
     def get_env(self):
         """Return env directives to be set after build"""
@@ -540,7 +567,6 @@ class BaseImage(BuildPack):
                 ("STENCILA_ARCHIVE", archive),
             ])
         return env
-
 
     def detect(self):
         return True

--- a/tests/venv/postBuild/postBuild
+++ b/tests/venv/postBuild/postBuild
@@ -1,2 +1,3 @@
 #!/bin/bash
 jupyter nbextension enable --py --sys-prefix ipyleaflet
+npm install --global configurable-http-proxy

--- a/tests/venv/postBuild/verify
+++ b/tests/venv/postBuild/verify
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 jupyter nbextension list | grep 'jupyter-leaflet' | grep enabled
+which configurable-http-proxy 


### PR DESCRIPTION
- defines NPM_DIR env and creates it at APP_BASE/npm
- tells npm to use this dir for `npm install --global`

closes #307

Related to #25, but not closing since this doesn't introduce package.json support or similar.