### PR TITLE
FIX: a temporary workaround for pip-19.0.1 issues

### DIFF
--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -63,6 +63,7 @@ class PythonBuildPack(CondaBuildPack):
         if os.path.exists(requirements_file):
             assemble_scripts.append((
                 '${NB_USER}',
+                'pip install "pip<19" && ' + \
                 '{} install --no-cache-dir -r "{}"'.format(pip, requirements_file)
             ))
 


### PR DESCRIPTION
We are experiencing issues with mybinder for this repo: https://github.com/NSLS-II/tutorial due to https://github.com/pypa/pip/issues/6197:
```py
Exception:
Traceback (most recent call last):
  File "/srv/conda/lib/python3.6/site-packages/pip/_internal/cli/base_command.py", line 176, in main
    status = self.run(options, args)
  File "/srv/conda/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 346, in run
    session=session, autobuilding=True
  File "/srv/conda/lib/python3.6/site-packages/pip/_internal/wheel.py", line 886, in build
    assert have_directory_for_build
AssertionError
Removing intermediate container b42459fcd7a3
The command '/bin/sh -c ${KERNEL_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r "requirements.txt"' returned a non-zero code: 2Error during build: 'Repo2Docker' object has no attribute 'debug'
```

This temporary fix may solve the issue, however I don't mind to just wait until after pip-19.0.2 with the fix is released. Just wanted to document it here.

Also, please note another error which I haven't attempt to solve:
```
Error during build: 'Repo2Docker' object has no attribute 'debug'
```
This is called here: https://github.com/jupyter/repo2docker/blob/9c2c7b6ae291fbb9c8147be332b64a0794d768e6/repo2docker/__main__.py#L337
Any ideas what it should be instead of `r2d.debug`?