### PR TITLE
pin conda during Python-switch step

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -63,7 +63,7 @@ fi
 # which seems to result in some effective pinning of packages in the initial env,
 # which we don't intend.
 # this file must not be *removed*, however
-echo '' > ${CONDA_DIR}/envs/kernel/conda-meta/history
+echo '' > ${CONDA_DIR}/conda-meta/history
 
 # Clean things out!
 conda clean -tipsy

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -57,12 +57,14 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
 
     conda env create -n kernel -f /tmp/kernel-environment.yml
     ${CONDA_DIR}/envs/kernel/bin/ipython kernel install --prefix "${CONDA_DIR}"
-    rm -f ${CONDA_DIR}/envs/kernel/conda-meta/history
+    echo '' > ${CONDA_DIR}/envs/kernel/conda-meta/history
 fi
-# remove conda history file,
+# empty conda history file,
 # which seems to result in some effective pinning of packages in the initial env,
-# which we don't intend
-rm -f ${CONDA_DIR}/conda-meta/history
+# which we don't intend.
+# this file must not be *removed*, however
+echo '' > ${CONDA_DIR}/envs/kernel/conda-meta/history
+
 # Clean things out!
 conda clean -tipsy
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -3,7 +3,7 @@
 set -ex
 
 cd $(dirname $0)
-MINICONDA_VERSION=4.5.11
+MINICONDA_VERSION=4.5.12
 CONDA_VERSION=4.5.12
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
@@ -13,7 +13,7 @@ chmod +x ${INSTALLER_PATH}
 
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="e1045ee415162f944b6aebfe560b8fee"
+MD5SUM="866ae9dff53ad0874e1d1a60b1ad1ef8"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.5.11
-CONDA_VERSION=4.5.11
+CONDA_VERSION=4.5.12
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 
@@ -38,7 +38,7 @@ conda install -yq conda==${CONDA_VERSION}
 # prevent pip installation.
 # we wouldn't have this issue if we did `conda env create`
 # instead of `conda env update` in these cases
-conda install -y $(cat /tmp/environment.yml | grep -o '\spython=.*')
+conda install -y $(cat /tmp/environment.yml | grep -o '\spython=.*') conda==${CONDA_VERSION}
 
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
@@ -70,3 +70,5 @@ conda clean -tipsy
 rm ${INSTALLER_PATH}
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
+
+conda list

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -3,8 +3,8 @@
 set -ex
 
 cd $(dirname $0)
-MINICONDA_VERSION=4.5.12
-CONDA_VERSION=4.5.12
+MINICONDA_VERSION=4.5.11
+CONDA_VERSION=4.5.11
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 
@@ -13,7 +13,7 @@ chmod +x ${INSTALLER_PATH}
 
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="866ae9dff53ad0874e1d1a60b1ad1ef8"
+MD5SUM="e1045ee415162f944b6aebfe560b8fee"
 
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -4,3 +4,5 @@ import sys
 assert sys.version_info[:2] == (3, 5), sys.version
 
 import numpy
+import conda
+assert conda.__version__ == '4.5.12', conda.__version__

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,4 +5,4 @@ assert sys.version_info[:2] == (3, 5), sys.version
 
 import numpy
 import conda
-assert conda.__version__ == '4.5.12', conda.__version__
+assert conda.__version__ == '4.5.11', conda.__version__


### PR DESCRIPTION
even with auto-update-conda disabled, switching Python version (which reinstalls conda) can end up upgrading to the latest conda

Avoid this by adding the conda pinning to that install stage

This should fix the recent failures on CI, which appear to be due to a bug in the recent conda 4.6