### PR TITLE
add pip freeze to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 - pip install -r dev-requirements.txt
 - python setup.py bdist_wheel
 - pip install dist/*.whl
+- pip freeze
 script:
 # cd into tests so CWD being repo2docker does not hide
 # possible issues with MANIFEST.in
@@ -21,10 +22,6 @@ script:
   else
     travis_retry pytest --durations 10 --cov repo2docker -v ${REPO_TYPE} || exit 1;
   fi;
-  popd;
-- pip install -r docs/doc-requirements.txt
-- pushd docs;
-  make html || exit 1;
   popd;
 after_success:
 - pip install codecov


### PR DESCRIPTION
running pip freeze on every test is super helpful for debugging when a dependency change starts causing test failures

and stop building docs on travis; we are building them on circle now