### PR TITLE
Make sure $HOME/.conda is owned by user

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -73,4 +73,10 @@ rm ${INSTALLER_PATH}
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
 
+# conda puts an environments.txt file under ${HOME}/.conda, and there isn't
+# really a way to turn it off. We explicitly make sure they're owned by the user,
+# since otherwise they may be owned by root when $HOME != $REPO_DIR
+# see https://github.com/jupyter/repo2docker/issues/604
+chown -R ${NB_USER}:${NB_USER} ${HOME}/.conda
+
 conda list

--- a/tests/venv/repo-path/verify
+++ b/tests/venv/repo-path/verify
@@ -8,3 +8,7 @@ assert sys.executable == '/srv/conda/bin/python'
 # Repo should be in /srv/repo
 assert os.path.exists('/srv/repo/verify')
 assert os.path.abspath(__file__) == '/srv/repo/verify'
+
+# Verify that ~/.conda is owned by current user, and not root
+assert os.stat(os.path.expanduser('~/.conda')).st_uid == 1000
+assert os.stat(os.path.expanduser('~/.conda/environments.txt')).st_uid == 1000


### PR DESCRIPTION
conda puts an environments.txt file under ${HOME}/.conda, and there isn't
really a way to turn it off. We explicitly make sure they're owned by the user,
since otherwise they may be owned by root when $HOME != $REPO_DIR

Ref https://github.com/jupyter/repo2docker/issues/604