### PR TITLE
[MRG] Add PR template with links to contrib docs and less focus on code contributions

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,7 @@
+<!--
+
+[Our guide to getting a PR merged](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged).
+
+About to propose a big change? Read [code contributions](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-code-contribution)
+to maximise the chances of it getting merged quickly.
+-->

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
 
-[Our guide to getting a PR merged](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged).
+Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.
 
-About to propose a big change? Read [code contributions](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-code-contribution)
-to maximise the chances of it getting merged quickly.
+About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.
+
 -->

--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -1,18 +1,18 @@
 # Contributing to repo2docker development
 
-## Process for making a code contribution
+## Process for making a contribution
 
-This outlines the process for getting changes to the code of
-repo2docker merged.
+This outlines the process for getting changes to the repo2docker project merged.
 
-* If your change is relatively significant, **open an issue to discuss**
-  before spending a lot of time writing code. Getting consensus with the
+* If your change is a big change, **open an issue to discuss**
+  before spending a lot of time writing. Getting consensus with the
   community is a great way to save time later.
 * Make edits in your fork of the repo2docker repository
-* Submit a pull request (this is how all changes are made)
+* All changes are made by submitting a pull request. Read the next section for
+  the guidelines for both reviewers and contributors on merging a PR.
 * Edit [the changelog](./../../changelog)
   by appending your feature / bug fix to the development version.
-* Wait for a community member to merge your changes
+* Wait for a community member to merge your changes.
 * (optional) Deploy a new version of repo2docker to mybinder.org by [following these steps](http://mybinder-sre.readthedocs.io/en/latest/deployment/how.html)
 
 


### PR DESCRIPTION
Add a PR template that links to two particular parts of our contributing docs that are otherwise several clicks away. It also rewords some sentences to remove the word "code".

The two things that are brought closer with this are our "guide to getting things merged" and "proposing big changes".

I think advice like "get consensus" applies to big changes to the docs just as much as for code changes. Hence proposing to remove the word code.