### PR TITLE
Expand environment.yml config notes

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -34,6 +34,8 @@ that lets you install any kind of package,
 including Python, R, and C/C++ packages.
 ``repo2docker`` does not use ``environment.yml`` to create and activate a new conda environment.
 Rather, it updates a base conda environment with the packages listed in ``environment.yml``.
+This means that the environment will always have the same name and not follow what is
+specified in ``environment.yml``.
 
 .. note::
 

--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -34,7 +34,7 @@ that lets you install any kind of package,
 including Python, R, and C/C++ packages.
 ``repo2docker`` does not use ``environment.yml`` to create and activate a new conda environment.
 Rather, it updates a base conda environment with the packages listed in ``environment.yml``.
-This means that the environment will always have the same name and not follow what is
+This means that the environment will always have the same default name, not the name
 specified in ``environment.yml``.
 
 .. note::

--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -32,6 +32,8 @@ Below is a list of supported configuration files (roughly in the order of build 
 ``environment.yml`` is the standard configuration file used by `conda <https://conda.io>`_
 that lets you install any kind of package,
 including Python, R, and C/C++ packages.
+``repo2docker`` does not use ``environment.yml`` to create and activate a new conda environment.
+Rather, it updates a base conda environment with the packages listed in ``environment.yml``.
 
 .. note::
 


### PR DESCRIPTION
This small config documentation update follows from https://github.com/jupyterhub/binder/issues/152#issuecomment-469668454 and https://github.com/jupyter/repo2docker/issues/411#issuecomment-462487697  Clarifying how `environment.yml` is used may help future users avoid the confusion I had.

This update is based on my understanding of
https://github.com/jupyter/repo2docker/blob/e6cbf3e3a3e399508d5628b4ff1d30afed8c944f/repo2docker/buildpacks/conda/__init__.py#L178-L186

I avoided getting too technical in the documentation about the role of frozen environments.