### PR TITLE
Allow URLs for Julia package requirements

### DIFF
--- a/repo2docker/buildpacks/julia/install-repo-dependencies.jl
+++ b/repo2docker/buildpacks/julia/install-repo-dependencies.jl
@@ -21,6 +21,8 @@ else
         version = try; reqline.versions.intervals[1].lower; catch; emptyversionlower; end
         if version != emptyversionlower
           Pkg.add(PackageSpec(name=pkg, version=version))
+        elseif startswith(pkg,"http://") || startswith(pkg,"https://")
+          Pkg.add(PackageSpec(url=pkg, rev="master"))
         else
           Pkg.add(pkg)
         end


### PR DESCRIPTION
This allows installing a Julia module by URL instead of name.

The main benefit is that one can also install non-registered Julia modules. The solution is not perfect, since the master branch is always used. It is however an improvement over not being able to prove URLs.