### PR TITLE
[WIP] tell IJulia to install jupyter kernels in /srv

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -63,7 +63,8 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
             ('JULIA_BINDIR', '${JULIA_PATH}/bin'),
             ('JULIA_DEPOT_PATH', '${JULIA_PATH}/pkg'),
             ('JULIA_VERSION', self.julia_version),
-            ('JUPYTER', '${NB_PYTHON_PREFIX}/bin/jupyter')
+            ('JUPYTER', '${NB_PYTHON_PREFIX}/bin/jupyter'),
+            ('JUPYTER_DATA_DIR', '${APP_BASE}/conda/share/jupyter')
         ]
 
     def get_path(self):

--- a/tests/julia/julia_version-default/verify
+++ b/tests/julia/julia_version-default/verify
@@ -4,6 +4,14 @@ if VERSION < v"1.1.0"
     exit(1)
 end
 
+# Verify that kernels are not installed in home directory (issue #620)
+try
+    using IJulia
+    @assert IJulia.kerneldir() == "/srv/conda/share/jupyter/kernels"
+catch
+    exit(1)
+end
+
 using Pkg
 pkg"activate ."
 


### PR DESCRIPTION
This PR adds an environment variable which tells IJulia to put its kernelspec in /srv
Potential fix for #620.

Todo:

- [ ] is this is the best way to find the kernel path?
- [x] figure out how to test
- [ ] update `docs/source/changelog.rst`

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
