### PR TITLE
[MRG] Julia: Two small doc updates

### DIFF
--- a/docs/source/howto/languages.rst
+++ b/docs/source/howto/languages.rst
@@ -73,10 +73,10 @@ Julia
 
 To build an environment with Julia, include a configuration file called
 ``Project.toml``. The format of this file is documented at
-`the Julia Pkg.jl documentation <https://julialang.github.io/Pkg.jl/stable/>`_.
+`the Julia Pkg.jl documentation <https://julialang.github.io/Pkg.jl/v1/>`_.
 To specify a specific version of Julia to install, put a Julia version in the
-``Compat`` section of the ``Project.toml`` file, as described
-here: https://julialang.github.io/Pkg.jl/stable/compatibility.
+``[compat]`` section of the ``Project.toml`` file, as described
+here: https://julialang.github.io/Pkg.jl/v1/compatibility/.
 
 Languages not covered here
 ==========================


### PR DESCRIPTION
Two doc-changes as a follow up on #595:
- update links to Pkg.jl documentation;
- change `Compat` to `[compat]` since that is usually how we refer to said section.