### PR TITLE
[MRG] Python 3.7 as the default in the docs

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -36,7 +36,7 @@ either because the version of the package is too new and your chosen Python is t
 or vice versa.
 
 I Python 2.7 is specified, a separate environment for the kernel will be
-installed with Python 2. The notebook server will run in the default Python 3.6
+installed with Python 2. The notebook server will run in the default Python 3.7
 environment.
 
 Julia

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -85,7 +85,7 @@ by ``repo2docker`` to see how to configure the build process.
 
 .. note::
 
-   ``repo2docker`` builds an environment with Python 3.6 by default. If you'd
+   ``repo2docker`` builds an environment with Python 3.7 by default. If you'd
    like a different version, you can specify this in your
    :ref:`configuration files <config-files>`.
 


### PR DESCRIPTION
The latest version of repo2docker (`0.8.0`) seems to be using Python 3.7 as the default.

This change updates the docs to reflect that.