### PR TITLE
[WIP] Bump conda version 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ New features
   :user:`davidanthoff`
 - Set JULIA_PROJECT globally, so that every julia instance starts with the
   julia environment activated in :pr:`612` by :user:`davidanthoff`.
-- Update Miniconda version to 4.5.12 and Conda version to 4.6.10  in :pr:`637` by
+- Update Miniconda version to 4.5.12 and Conda version to 4.6.9  in :pr:`637` by
   :user:`jhamman`
 
 API changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,8 @@ New features
   :user:`davidanthoff`
 - Set JULIA_PROJECT globally, so that every julia instance starts with the
   julia environment activated in :pr:`612` by :user:`davidanthoff`.
+- Update Miniconda version to 4.5.12and Conda version to 4.6.11  in :pr:`637` by
+  :user:`jhamman`
 
 API changes
 -----------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ New features
   :user:`davidanthoff`
 - Set JULIA_PROJECT globally, so that every julia instance starts with the
   julia environment activated in :pr:`612` by :user:`davidanthoff`.
-- Update Miniconda version to 4.5.12and Conda version to 4.6.11  in :pr:`637` by
+- Update Miniconda version to 4.5.12 and Conda version to 4.6.10  in :pr:`637` by
   :user:`jhamman`
 
 API changes

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-03-23 18:02:15 UTC
+# Frozen on 2019-04-04 20:24:39 UTC
 name: r2d
 channels:
   - conda-forge
@@ -27,7 +27,9 @@ dependencies:
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
+  - libgcc-ng=8.2.0=hdf63c60_1
   - libsodium=1.0.16=h14c3975_1001
+  - libstdcxx-ng=8.2.0=hdf63c60_1
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
@@ -46,7 +48,7 @@ dependencies:
   - ptyprocess=0.6.0=py37_1000
   - pygments=2.3.1=py_0
   - pyrsistent=0.14.11=py37h14c3975_0
-  - python=3.7.2=h381d211_0
+  - python=3.7.3=h5b0a415_0
   - python-dateutil=2.8.0=py_0
   - pyzmq=18.0.1=py37h0e1adb2_0
   - readline=7.0=hf8c457e_1001
@@ -54,10 +56,10 @@ dependencies:
   - setuptools=40.8.0=py37_0
   - six=1.12.0=py37_1000
   - sqlite=3.26.0=h67949de_1001
-  - terminado=0.8.1=py37_1001
+  - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1000
-  - tornado=6.0.1=py37h14c3975_0
+  - tk=8.6.9=h84994c4_1001
+  - tornado=6.0.2=py37h516909a_0
   - traitlets=4.3.2=py37_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
@@ -66,8 +68,6 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.2.5=hf484d3e_1006
   - zlib=1.2.11=h14c3975_1004
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libstdcxx-ng=8.2.0=hdf63c60_1
   - pip:
     - alembic==1.0.8
     - async-generator==1.10
@@ -80,7 +80,7 @@ dependencies:
     - python-editor==1.0.4
     - python-oauth2==1.1.0
     - requests==2.21.0
-    - sqlalchemy==1.3.1
+    - sqlalchemy==1.3.2
     - urllib3==1.24.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-03-23 17:59:14 UTC
+# Frozen on 2019-04-04 20:21:17 UTC
 name: r2d
 channels:
   - conda-forge
@@ -20,7 +20,9 @@ dependencies:
   - jupyter_client=5.2.4=py_3
   - jupyter_core=4.4.0=py_0
   - libffi=3.2.1=he1b5a44_1006
+  - libgcc-ng=8.2.0=hdf63c60_1
   - libsodium=1.0.16=h14c3975_1001
+  - libstdcxx-ng=8.2.0=hdf63c60_1
   - ncurses=6.1=hf484d3e_1002
   - openssl=1.1.1b=h14c3975_1
   - pathlib2=2.3.3=py27_1000
@@ -40,14 +42,12 @@ dependencies:
   - singledispatch=3.4.0.3=py27_1000
   - six=1.12.0=py27_1000
   - sqlite=3.26.0=h67949de_1001
-  - tk=8.6.9=h84994c4_1000
+  - tk=8.6.9=h84994c4_1001
   - tornado=5.1.1=py27h14c3975_1000
   - traitlets=4.3.2=py27_1000
   - wcwidth=0.1.7=py_1
   - wheel=0.33.1=py27_0
   - zeromq=4.2.5=hf484d3e_1006
   - zlib=1.2.11=h14c3975_1004
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libstdcxx-ng=8.2.0=hdf63c60_1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-03-23 18:00:20 UTC
+# Frozen on 2019-04-04 20:22:30 UTC
 name: r2d
 channels:
   - conda-forge
@@ -26,7 +26,9 @@ dependencies:
   - jupyterlab=0.35.4=py36_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
+  - libgcc-ng=8.2.0=hdf63c60_1
   - libsodium=1.0.16=h14c3975_1001
+  - libstdcxx-ng=8.2.0=hdf63c60_1
   - markupsafe=1.1.1=py36h14c3975_0
   - mistune=0.8.4=py36h14c3975_1000
   - nbconvert=5.4.1=py_2
@@ -53,10 +55,10 @@ dependencies:
   - setuptools=40.8.0=py36_0
   - six=1.12.0=py36_1000
   - sqlite=3.26.0=h67949de_1001
-  - terminado=0.8.1=py36_1001
+  - terminado=0.8.2=py36_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1000
-  - tornado=6.0.1=py36h14c3975_0
+  - tk=8.6.9=h84994c4_1001
+  - tornado=6.0.2=py36h516909a_0
   - traitlets=4.3.2=py36_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
@@ -65,8 +67,6 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.2.5=hf484d3e_1006
   - zlib=1.2.11=h14c3975_1004
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libstdcxx-ng=8.2.0=hdf63c60_1
   - pip:
     - alembic==1.0.8
     - async-generator==1.10
@@ -79,7 +79,7 @@ dependencies:
     - python-editor==1.0.4
     - python-oauth2==1.1.0
     - requests==2.21.0
-    - sqlalchemy==1.3.1
+    - sqlalchemy==1.3.2
     - urllib3==1.24.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-03-23 18:00:20 UTC
+# Generated on 2019-04-04 20:22:30 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.4.2

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-03-23 18:02:15 UTC
+# Frozen on 2019-04-04 20:24:39 UTC
 name: r2d
 channels:
   - conda-forge
@@ -27,7 +27,9 @@ dependencies:
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
+  - libgcc-ng=8.2.0=hdf63c60_1
   - libsodium=1.0.16=h14c3975_1001
+  - libstdcxx-ng=8.2.0=hdf63c60_1
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
@@ -46,7 +48,7 @@ dependencies:
   - ptyprocess=0.6.0=py37_1000
   - pygments=2.3.1=py_0
   - pyrsistent=0.14.11=py37h14c3975_0
-  - python=3.7.2=h381d211_0
+  - python=3.7.3=h5b0a415_0
   - python-dateutil=2.8.0=py_0
   - pyzmq=18.0.1=py37h0e1adb2_0
   - readline=7.0=hf8c457e_1001
@@ -54,10 +56,10 @@ dependencies:
   - setuptools=40.8.0=py37_0
   - six=1.12.0=py37_1000
   - sqlite=3.26.0=h67949de_1001
-  - terminado=0.8.1=py37_1001
+  - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1000
-  - tornado=6.0.1=py37h14c3975_0
+  - tk=8.6.9=h84994c4_1001
+  - tornado=6.0.2=py37h516909a_0
   - traitlets=4.3.2=py37_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
@@ -66,8 +68,6 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.2.5=hf484d3e_1006
   - zlib=1.2.11=h14c3975_1004
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libstdcxx-ng=8.2.0=hdf63c60_1
   - pip:
     - alembic==1.0.8
     - async-generator==1.10
@@ -80,7 +80,7 @@ dependencies:
     - python-editor==1.0.4
     - python-oauth2==1.1.0
     - requests==2.21.0
-    - sqlalchemy==1.3.1
+    - sqlalchemy==1.3.2
     - urllib3==1.24.1
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-03-23 18:02:15 UTC
+# Generated on 2019-04-04 20:24:39 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.4.2

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -21,8 +21,8 @@ from ruamel.yaml import YAML
 
 # Docker image version can be different than conda version,
 # since miniconda3 docker images seem to lag conda releases.
-MINICONDA_DOCKER_VERSION = '4.5.11'
-CONDA_VERSION = '4.5.11'
+MINICONDA_DOCKER_VERSION = '4.5.12'
+CONDA_VERSION = '4.6.9'
 
 HERE = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.5.12
-CONDA_VERSION=4.6.11
+CONDA_VERSION=4.6.10
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
 MD5SUM="866ae9dff53ad0874e1d1a60b1ad1ef8"

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -3,8 +3,8 @@
 set -ex
 
 cd $(dirname $0)
-MINICONDA_VERSION=4.5.11
-CONDA_VERSION=4.5.11
+MINICONDA_VERSION=4.5.12
+CONDA_VERSION=4.6.11
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -5,6 +5,10 @@ set -ex
 cd $(dirname $0)
 MINICONDA_VERSION=4.5.12
 CONDA_VERSION=4.6.11
+# Only MD5 checksums are available for miniconda
+# Can be obtained from https://repo.continuum.io/miniconda/
+MD5SUM="4be03f925e992a8eda03758b72a77298"
+
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh
 
@@ -15,10 +19,7 @@ unset HOME
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-# Only MD5 checksums are available for miniconda
-# Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="e1045ee415162f944b6aebfe560b8fee"
-
+# check md5 checksum
 if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
     exit 1

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.5.12
-CONDA_VERSION=4.6.10
+CONDA_VERSION=4.6.9
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
 MD5SUM="866ae9dff53ad0874e1d1a60b1ad1ef8"

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -7,7 +7,7 @@ MINICONDA_VERSION=4.5.12
 CONDA_VERSION=4.6.11
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="4be03f925e992a8eda03758b72a77298"
+MD5SUM="866ae9dff53ad0874e1d1a60b1ad1ef8"
 
 URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniconda-installer.sh


### PR DESCRIPTION
This bumps the miniconda version to 4.5.12 (latest) and the conda version to 4.6.11 (latest). Conda 4.6 included a number of performance improvements that should help speed up install times for complex environments. It also included some improvements to conda's interoperability with pip. An overview of the conda release is available here: https://www.anaconda.com/conda-4-6-release/.

Fixes #593