### PR TITLE
[MRG] Remove conda download cache explicitly

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -181,7 +181,8 @@ class CondaBuildPack(BaseImage):
                 r"""
                 conda env update -n {0} -f "{1}" && \
                 conda clean -tipsy && \
-                conda list -n {0}
+                conda list -n {0} && \
+                rm -rf /srv/conda/pkgs
                 """.format(env_name, environment_yml)
             ))
         return super().get_assemble_scripts() + assembly_scripts


### PR DESCRIPTION
Investigate what happens if we delete the download cache of conda packages.

If I build https://github.com/binder-examples/conda with `master` I get an image which is 2.04GB according to `docker images` and if I build the same repo with this PR I have one that is 2GB.

@rabernat what do you use to measure the image sizes? (I've never really looked into this before).

Fixes #636 