### PR TITLE
[MRG] Ensure git submodules are updated and initialized

### DIFF
--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -45,6 +45,12 @@ class Git(ContentProvider):
                                     capture=yield_output):
                 yield line
 
+        # ensure that git submodules are initialised and updated
+        for line in execute_cmd(['git', 'submodule', 'update', '--init', '--recursive'],
+                                cwd=output_dir,
+                                capture=yield_output):
+            yield line
+
         cmd = ['git', 'rev-parse', 'HEAD']
         sha1 = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=output_dir)
         self._sha1 = sha1.stdout.read().decode().strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,8 +136,10 @@ def repo_with_submodule():
         # create "parent" repository
         subprocess.check_call(['git', 'init'], cwd=git_a_dir)
         _add_content_to_git(git_a_dir)
-        # create submodule repository
+        # create repository with 2 commits that will be the submodule
         subprocess.check_call(['git', 'init'], cwd=git_b_dir)
+        _add_content_to_git(git_b_dir)
+        submod_sha1_b = _get_sha1(git_b_dir)
         _add_content_to_git(git_b_dir)
 
         # create a new branch in the parent to add the submodule
@@ -145,14 +147,16 @@ def repo_with_submodule():
                               cwd=git_a_dir)
         subprocess.check_call(['git', 'submodule', 'add', git_b_dir, 'submod'],
                               cwd=git_a_dir)
+        # checkout the first commit for the submod, not the latest
+        subprocess.check_call(['git', 'checkout', submod_sha1_b],
+                              cwd=os.path.join(git_a_dir, 'submod'))
         subprocess.check_call(['git', 'add', git_a_dir, ".gitmodules"],
                               cwd=git_a_dir)
         subprocess.check_call(['git', 'commit', '-m', 'Add B repos submod'],
                               cwd=git_a_dir)
 
         sha1_a = _get_sha1(git_a_dir)
-        sha1_b = _get_sha1(git_b_dir)
-        yield git_a_dir, sha1_a, sha1_b
+        yield git_a_dir, sha1_a, submod_sha1_b
 
 
 class Repo2DockerTest(pytest.Function):

--- a/tests/unit/contentproviders/test_git.py
+++ b/tests/unit/contentproviders/test_git.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import subprocess
 from tempfile import TemporaryDirectory
 from repo2docker.contentproviders import Git
 
@@ -16,6 +17,28 @@ def test_clone(repo_with_content):
         assert os.path.exists(os.path.join(clone_dir, 'test'))
 
         assert git_content.content_id == sha1[:7]
+
+
+def test_submodule_clone(repo_with_submodule):
+    """Test git clone containing a git submodule."""
+    upstream, sha1_upstream, sha1_submod = repo_with_submodule
+
+    with TemporaryDirectory() as clone_dir:
+        submod_dir = os.path.join(clone_dir, 'submod')  # set by fixture
+        spec = {'repo': upstream}
+        git_content = Git()
+        for _ in git_content.fetch(spec, clone_dir):
+            pass
+        assert os.path.exists(os.path.join(clone_dir, 'test'))
+        assert os.path.exists(os.path.join(submod_dir, 'test'))
+
+        # get current sha1 of submodule
+        cmd = ['git', 'rev-parse', 'HEAD']
+        sha1 = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=submod_dir)
+        submod_sha1 = sha1.stdout.read().decode().strip()
+
+        assert git_content.content_id == sha1_upstream[:7]
+        assert submod_sha1[:7] == submod_sha1[:7]
 
 
 def test_bad_ref(repo_with_content):

--- a/tests/unit/contentproviders/test_git.py
+++ b/tests/unit/contentproviders/test_git.py
@@ -21,7 +21,7 @@ def test_clone(repo_with_content):
 
 def test_submodule_clone(repo_with_submodule):
     """Test git clone containing a git submodule."""
-    upstream, sha1_upstream, sha1_submod = repo_with_submodule
+    upstream, expected_sha1_upstream, expected_sha1_submod = repo_with_submodule
 
     with TemporaryDirectory() as clone_dir:
         submod_dir = os.path.join(clone_dir, 'submod')  # set by fixture
@@ -37,8 +37,8 @@ def test_submodule_clone(repo_with_submodule):
         sha1 = subprocess.Popen(cmd, stdout=subprocess.PIPE, cwd=submod_dir)
         submod_sha1 = sha1.stdout.read().decode().strip()
 
-        assert git_content.content_id == sha1_upstream[:7]
-        assert submod_sha1[:7] == submod_sha1[:7]
+        assert git_content.content_id == expected_sha1_upstream[:7]
+        assert submod_sha1[:7] == expected_sha1_submod[:7]
 
 
 def test_bad_ref(repo_with_content):


### PR DESCRIPTION
This is a continuation of #540. See that PR for details. That PR by @alimanfoo was only missing a test so this is my attempt at adding one.

Some things to note:

1. Should I merge or rebase upstream or leave this branch where it is?
2. I'm not a pytest fixture expert, but I don't think there was a cleaner way of doing what I needed to do to create the git repositories. I separated out the functionality of `repo_with_content` so I could reuse them in my new fixture.
3. After creating the fixture, I then realized there was no builtin way to get the submodule's SHA without running some commands with subprocess. It made the git unit tests uglier, but I wasn't sure what else to do.
4. As part of point 2 above, I changed the functionality of adding content to a test repository to use append so theoretically someone could call the same method multiple times to create multiple commits.

I think this tests what it needs to test, but may not be how the maintainers want this structured. Let me know what you want changed. Git tests pass locally.