### PR TITLE
[MRG] Fix handling of memory limit command line argument

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -300,7 +300,7 @@ def make_r2d(argv=None):
 
     if args.build_memory_limit:
         # if the string only contains numerals we assume it should be an int
-        # and specifies a size inn bytes
+        # and specifies a size in bytes
         if args.build_memory_limit.isnumeric():
             r2d.build_memory_limit = int(args.build_memory_limit)
         else:

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -299,7 +299,12 @@ def make_r2d(argv=None):
         r2d.user_name = args.user_name
 
     if args.build_memory_limit:
-        r2d.build_memory_limit = args.build_memory_limit
+        # if the string only contains numerals we assume it should be an int
+        # and specifies a size inn bytes
+        if args.build_memory_limit.isnumeric():
+            r2d.build_memory_limit = int(args.build_memory_limit)
+        else:
+            r2d.build_memory_limit = args.build_memory_limit
 
     if args.environment and not r2d.run:
         print('To specify environment variables, you also need to run '

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -40,6 +40,17 @@ def test_dry_run():
     assert not r2d.run
     assert not r2d.push
 
+
+def test_mem_limit():
+    """
+    Test various ways of passing --build-memory-limit
+    """
+    r2d = make_r2d(['--build-memory-limit', '1024', '.'])
+    assert int(r2d.build_memory_limit) == 1024
+
+    r2d = make_r2d(['--build-memory-limit', '3K', '.'])
+    assert int(r2d.build_memory_limit) == 1024 * 3
+
 def test_run_required():
     """
     Test all the things that should fail if we pass in --no-run


### PR DESCRIPTION
If a string of only numerals is passed as argument we assume it should
be converted to an integer and specifies a size in bytes.

When BinderHub constructs the `repo2docker` command-line it [passes a value in bytes without a suffix](https://travis-ci.org/jupyterhub/mybinder.org-deploy/builds/525264674#L1113-L1135). This is with a value of `"3G"` set in the `values.yaml`.

I think this will allow us to try out https://github.com/jupyterhub/mybinder.org-deploy/pull/954