### PR TITLE
[MRG] Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us repair something that is currently broken
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Steps to reproduce the behaviour:
 **Expected behaviour**
 A clear and concise description of what you expected to happen.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Versions (please complete the following information):**
+ - OS: [e.g. linux, OSX]
+ - Docker version: `docker version`
+ - repo2docker version `repo2docker --version`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a new feature or a big change to repo2docker
+title: ''
+labels: 'needs: discussion'
+assignees: ''
+
+---
+
+Those who maintain this project do so as volunteers and we have no control over their schedule or priorities.
+
+This means if the feature you are proposing is something you'd like to see added the best way to achieve that is for you to organise the effort required to build it. This could be evangelising for the feature, paying someone, doing it yourself, etc.
+
+Even so it might never get merged because the trade off between additional happy users and maintenance burden is not favourable.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -1,0 +1,14 @@
+---
+name: Support question
+about: Ask a question about using repo2docker
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+🚨 Please do **not** open an issue for support questions. Instead please search for similar issues or post on http://discourse.jupyter.org/c/questions. 🚨
+
+More people read the forum than this issue tracker, it is indexed by search engines and easier for others to discover.
+
+For more details: https://discourse.jupyter.org/t/a-proposal-for-jupyterhub-communications/505


### PR DESCRIPTION
Add issue templates for the different kinds of questions people might have.

* support questions are directed to discourse
* bug reports ask for some details about the platform, versions, etc
* feature requests contain a note that let people know that the best way to get a feature implemented is to "do it yourself". Where "do it yourself" doesn't mean "write the code" but more facilitate it by providing resources, etc. And that even then there are no promises that something will get merged because of the maintenance burden it adds.

This was sparked from a discussion with @KirstieJane about setting expectations for people opening issues.