### PR TITLE
Make sure ENTRYPOINT is an absolute path

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -668,7 +668,12 @@ class BaseImage(BuildPack):
         return []
 
     def get_start_script(self):
-        start = self.binder_path('./start')
+        start = self.binder_path('start')
         if os.path.exists(start):
-            return start
+            # Return an absolute path to start
+            # This is important when built container images start with
+            # a working directory that is different from ${REPO_DIR}
+            # This isn't a problem with anything else, since start is
+            # the only path evaluated at container start time rather than build time
+            return os.path.join('${REPO_DIR}', start)
         return None


### PR DESCRIPTION
Unlike other parts of the generated Dockerfile,
the start script is evaluated at run time, rather
than at build time. Currently, we assume that the
current working directory is the same at runtime
as build time for the start script. This doesn't
hold true always, and particularly not in JupyterHub
environments where ${HOME} is often overlaid with
a persistent directory.

We change this to always refer to the full path,
using the ${REPO_DIR} environment variable. This
lets people building JupyterHub images to set
REPO_DIR to something like /srv/repo (like hubploy
does), and still have a working start script.

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
