### PR TITLE
[MRG] Remove the conda package cache as we can't hardlink to it

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -182,9 +182,8 @@ class CondaBuildPack(BaseImage):
                 '${NB_USER}',
                 r"""
                 conda env update -p {0} -f "{1}" && \
-                conda clean -tipsy && \
-                conda list -p {0} && \
-                rm -rf /srv/conda/pkgs
+                conda clean --all -f -y && \
+                conda list -p {0}
                 """.format(env_prefix, environment_yml)
             ))
         return super().get_assemble_scripts() + assembly_scripts

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -69,6 +69,7 @@ fi
 
 # Clean things out!
 conda clean -tipsy
+rm -rf /srv/conda/pkgs
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -68,12 +68,12 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
 fi
 
 # Clean things out!
-conda clean -tipsy
-rm -rf /srv/conda/pkgs
+conda clean --all -f -y
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
-# Remove pip cache created as part of installing miniconda
+
+# Remove the pip cache created as part of installing miniconda
 rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -73,6 +73,8 @@ rm -rf /srv/conda/pkgs
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
+# Remove pip cache created as part of installing miniconda
+rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
 


### PR DESCRIPTION
This shrinks our "base" image by about 50MB plus 40MB from the second commit.

You can see the size of the "install miniconda" layer in various scenarios here:
* with `master` https://microbadger.com/images/betatim/r2d-minimal-python (330MB)
* with this PR https://microbadger.com/images/betatim/r2d-minimal-python-2 (270MB)
* before we had a separate conda env for ocnda itself https://microbadger.com/images/betatim/binder-example-requirements (218MB)

Maybe there is more saving potential somewhere, this was low hanging fruit. If someone knows a tool to see which files get created by each layer we could check for other temporary files left over that can be deleted.