### PR TITLE
[MRG] Do not try to build the image with root as the primary user.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,8 @@ API changes
 
 Bug fixes
 ---------
+- Prevent building the image as root if --user-id and --user-name are not specified
+  in :pr:`676` by :user:`Xarthisius`.
 
 
 Version 0.9.0

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -8,6 +8,7 @@ Usage:
     python -m repo2docker https://github.com/you/your-repo
 """
 import argparse
+import errno
 import json
 import sys
 import logging
@@ -650,6 +651,19 @@ class Repo2Docker(Application):
                                extra=dict(phase='building'))
 
                 if not self.dry_run:
+                    if os.geteuid() == 0:
+                        self.log.error(
+                            'Root as the primary user in the image is not permitted.\n'
+                        )
+                        self.log.info(
+                            "The uid and the username of the user invoking repo2docker "
+                            "is used to create a mirror account in the image by default. "
+                            "To override that behavior pass --user-id <numeric_id> and "
+                            " --user-name <string> to repo2docker.\n"
+                            "Please see repo2docker --help for more details.\n"
+                        )
+                        sys.exit(errno.EPERM)
+
                     build_args = {
                         'NB_USER': self.user_name,
                         'NB_UID': str(self.user_id),

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,3 +1,5 @@
+import errno
+import pytest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -102,3 +104,14 @@ def test_run_kwargs(repo_with_content):
     args, kwargs = containers.run.call_args
     assert 'somekey' in kwargs
     assert kwargs['somekey'] == "somevalue"
+
+
+def test_root_not_allowed():
+    with TemporaryDirectory() as src, patch('os.geteuid') as geteuid:
+        geteuid.return_value = 0
+        app = Repo2Docker()
+        argv = [src]
+        app = make_r2d(argv)
+        with pytest.raises(SystemExit) as exc:
+            app.build()
+            assert exc.code == errno.EPERM


### PR DESCRIPTION
Fixes #267 and #395. Solution suggested in https://github.com/jupyter/repo2docker/issues/267#issuecomment-478691267