### PR TITLE
Revert "[MRG] Do not try to build the image with root as the primary user."

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,8 +16,6 @@ API changes
 
 Bug fixes
 ---------
-- Prevent building the image as root if --user-id and --user-name are not specified
-  in :pr:`676` by :user:`Xarthisius`.
 
 
 Version 0.9.0

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -8,7 +8,6 @@ Usage:
     python -m repo2docker https://github.com/you/your-repo
 """
 import argparse
-import errno
 import json
 import sys
 import logging
@@ -651,19 +650,6 @@ class Repo2Docker(Application):
                                extra=dict(phase='building'))
 
                 if not self.dry_run:
-                    if os.geteuid() == 0:
-                        self.log.error(
-                            'Root as the primary user in the image is not permitted.\n'
-                        )
-                        self.log.info(
-                            "The uid and the username of the user invoking repo2docker "
-                            "is used to create a mirror account in the image by default. "
-                            "To override that behavior pass --user-id <numeric_id> and "
-                            " --user-name <string> to repo2docker.\n"
-                            "Please see repo2docker --help for more details.\n"
-                        )
-                        sys.exit(errno.EPERM)
-
                     build_args = {
                         'NB_USER': self.user_name,
                         'NB_UID': str(self.user_id),

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,3 @@
-import errno
-import pytest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -104,14 +102,3 @@ def test_run_kwargs(repo_with_content):
     args, kwargs = containers.run.call_args
     assert 'somekey' in kwargs
     assert kwargs['somekey'] == "somevalue"
-
-
-def test_root_not_allowed():
-    with TemporaryDirectory() as src, patch('os.geteuid') as geteuid:
-        geteuid.return_value = 0
-        app = Repo2Docker()
-        argv = [src]
-        app = make_r2d(argv)
-        with pytest.raises(SystemExit) as exc:
-            app.build()
-            assert exc.code == errno.EPERM


### PR DESCRIPTION
Reverts jupyter/repo2docker#676

@sgibson91 tried to deploy this to mybinder.org just now and it failed. The log of the deploy job is at https://travis-ci.org/jupyterhub/mybinder.org-deploy/builds/530202815#L1117-L1138 Reverting this so we can keep deploying changes and don't have the stress of having to fix this to unblock deploys.

I think we need to extend the check from "is the user root" to "is the user root and didn't user --user-id".