### PR TITLE
Do not try to build the image with root as the primary user

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,8 @@ API changes
 
 Bug fixes
 ---------
+- Prevent building the image as root if --user-id and --user-name are not specified
+  in :pr:`676` by :user:`Xarthisius`.
 
 
 Version 0.9.0

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -8,6 +8,7 @@ Usage:
     python -m repo2docker https://github.com/you/your-repo
 """
 import argparse
+import errno
 import json
 import sys
 import logging
@@ -650,6 +651,19 @@ class Repo2Docker(Application):
                                extra=dict(phase='building'))
 
                 if not self.dry_run:
+                    if self.user_id == 0:
+                        self.log.error(
+                            'Root as the primary user in the image is not permitted.\n'
+                        )
+                        self.log.info(
+                            "The uid and the username of the user invoking repo2docker "
+                            "is used to create a mirror account in the image by default. "
+                            "To override that behavior pass --user-id <numeric_id> and "
+                            " --user-name <string> to repo2docker.\n"
+                            "Please see repo2docker --help for more details.\n"
+                        )
+                        sys.exit(errno.EPERM)
+
                     build_args = {
                         'NB_USER': self.user_name,
                         'NB_UID': str(self.user_id),


### PR DESCRIPTION
This a redo of https://github.com/jupyter/repo2docker/pull/676. It errors r2d when root users try to run it without `--user-id` specified. The difference between this PR and #676 is that check is done against `self.user_id`. PTAL @betatim 