### PR TITLE
[MRG] Use getpass instead of pwd to fetch username

### DIFF
--- a/repo2docker/__init__.py
+++ b/repo2docker/__init__.py
@@ -1,3 +1,5 @@
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+from .app import Repo2Docker

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -7,13 +7,12 @@ Usage:
 
     python -m repo2docker https://github.com/you/your-repo
 """
-import argparse
 import errno
 import json
 import sys
 import logging
 import os
-import pwd
+import getpass
 import shutil
 import tempfile
 import time
@@ -213,7 +212,7 @@ class Repo2Docker(Application):
         """
         Default user_name to current running user.
         """
-        return pwd.getpwuid(os.getuid()).pw_name
+        return getpass.getuser()
 
     appendix = Unicode(
         config=True,

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -5,6 +5,20 @@ import os
 import subprocess
 import tempfile
 import time
+from unittest import mock
+
+from repo2docker import Repo2Docker
+
+
+def test_automatic_username_deduction():
+    # check we pickup the right username
+    with mock.patch('os.environ') as mock_env:
+        expected = 'someusername'
+        mock_env.get.return_value = expected
+
+        r2d = Repo2Docker()
+        assert r2d.user_name == expected
+
 
 def test_user():
     """


### PR DESCRIPTION
`getpass` is available on windows as well as unix, whereas `pwd` is not
available on windows.

`getpass.getuser()` also looks are environment variables which means users can trivially change the value. I don't think this is a problem for us as we don't use it for access control and give users a way to set this to arbitrary values via CLI flag already.

Using this instead of `pwd` means we are a bit closer to working on Windows which is nice even though we don't officially support the windows platform. Unless there is a strong reason to I'd vote for taking the option that does not break Windows.

Not quite sure how to test this :-/