### PR TITLE
[MRG] Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
   - secure: KoOOJUp60vtvx/mXzoZWpvWgB6W3rr8I0gDWL2laCTgxo6HsTL+SSOY1l12SBE2jlvFmQqVwPPBfnp5Dudna2RQFF36eO2jUlISBkvK/q/GRmOQbjpAJRtVlan8Z4dlIf4az/oQ9G0ZUEfgUliVvS5MTrEPvKej3znug2zAH1t+H0U6aon1VJeVC+b94jsETGvQ7HHupqrr+DNGrNVHOgAazw7z4j+VtfZyfNaglnrKwYPeUljw3GIOXyFmP81t/cLiDY+IjPPepUYJFQIjCoVpIDm6UR70d4mzWf/LYWONEdh8LhDJZ2UyEtnUT2IPTdhqem1BfCAKUcLedHPk3S4Lcn0jL23os0klHeQvn9JRPEDV/Ib33XGcNEIXZi0pBkluUyhx8JgTz4e+KL8jKcyf9TRX7o/ViH7Ler6viliyMu15yfs2mJKAxzw6GFMtqGzhJ8tUXjguTozfjKTJKjBpkFoYdYbO9GqNkBQo2F7H+8zAmb4D4K0jzfOo8owjYLXJzOMJN5f5pKBqfLdjOtTxve4PrCgy4B8x7GDkW41SuRz2pkVwRDMMJRCetLcbqpEK+8b9Oy/inlxt7/56oS/tvvAtBj2FlLGBPQJKpwyZozIY9XqXWu8u+VbRsSTqbRtdSHzzKyQ25a03dc7KDHmyoDAlzyehe6cHPWp1UqXg=
 matrix:
   include:
-  - python: 3.4
+  - python: 3.5
     env:
     - REPO_TYPE=venv
 deploy:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to learn about where the project is heading.
 
 1. Docker to build & run the repositories. The [community edition](https://store.docker.com/search?type=edition&offering=community)
    is recommended.
-2. Python 3.4+.
+2. Python 3.5+.
 
 Supported on Linux and macOS. [See documentation note about Windows support.](http://repo2docker.readthedocs.io/en/latest/install.html#note-about-windows-support)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,8 @@ Release date: TBD
 
 New features
 ------------
+- Increased minimum Python version supported for running  `repo2docker` itself
+  to Python 3.5 in :pr:`684` by :user:`betatim`.
 
 API changes
 -----------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@
 Installing ``repo2docker``
 ==========================
 
-repo2docker requires Python 3.4 and above on Linux and macOS. See
+repo2docker requires Python 3.5 and above on Linux and macOS. See
 :ref:`below <windows>` for more information about Windows support.
 
 Prerequisite: Docker

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ setup(
         'toml',
         'semver',
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     author='Project Jupyter Contributors',
     author_email='jupyter@googlegroups.com',
     url='https://repo2docker.readthedocs.io/en/latest/',
-    project_urls = {
+    project_urls={
         'Documentation': 'https://repo2docker.readthedocs.io',
         'Funding': 'https://jupyter.org/about',
         'Source': 'https://github.com/jupyter/repo2docker/',
@@ -33,11 +33,11 @@ setup(
     },
     # this should be a whitespace separated string of keywords, not a list
     keywords="reproducible science environments docker",
-    description = "Repo2docker: Turn code repositories into Jupyter enabled Docker Images",
-    long_description = readme,
-    long_description_content_type = 'text/markdown',
+    description="Repo2docker: Turn code repositories into Jupyter enabled Docker Images",
+    long_description=readme,
+    long_description_content_type='text/markdown',
     license='BSD',
-    classifiers = [
+    classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
This PR drops support for running repo2docker on a system that has Python 3.4 only. This does not effect users ability to build repositories that need Python 3.4

Why? One of our dependencies has stopped shipping wheels for Python 3.4 because https://www.python.org/dev/peps/pep-0429/ states that the last release of Python 3.4 was in March 2019.

There are two questions here:
* should we also drop Python 3.4 support?
* why does our travis setup not install ruamel.yaml "from source" but fail when there are no wheels? https://travis-ci.org/jupyter/repo2docker/jobs/535148903#L643