### PR TITLE
Switch Travis CI to Ubuntu Xenial 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: required
 cache: pip


### PR DESCRIPTION
This PR updates Travis CI to use Ubuntu 16.04. Fixes #685