### PR TITLE
set CONDA_DEFAULT_ENV

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -36,6 +36,13 @@ class CondaBuildPack(BaseImage):
             env.append(('KERNEL_PYTHON_PREFIX', '${NB_PYTHON_PREFIX}'))
         return env
 
+    def get_env(self):
+        """Make kernel env the default for `conda install`"""
+        env = super().get_env() + [
+            ('CONDA_DEFAULT_ENV', '${KERNEL_PYTHON_PREFIX}'),
+        ]
+        return env
+
     def get_path(self):
         """Return paths (including conda environment path) to be added to
         the PATH environment variable.

--- a/repo2docker/buildpacks/conda/activate-conda.sh
+++ b/repo2docker/buildpacks/conda/activate-conda.sh
@@ -3,9 +3,16 @@ CONDA_PROFILE="${CONDA_DIR}/etc/profile.d/conda.sh"
 test -f $CONDA_PROFILE && . $CONDA_PROFILE
 if [[ "${KERNEL_PYTHON_PREFIX}" != "${NB_PYTHON_PREFIX}" ]]; then
     # if the kernel is a separate env, stack them
-    # so both are on PATH
+    # so both are on PATH, notebook first
     conda activate ${KERNEL_PYTHON_PREFIX}
     conda activate --stack ${NB_PYTHON_PREFIX}
+
+    # even though it's second on $PATH
+    # make sure CONDA_DEFAULT_ENV is the *kernel* env
+    # so that `!conda install PKG` installs in the kernel env
+    # where user packages are installed, not the notebook env
+    # which only contains UI when the two are different
+    export CONDA_DEFAULT_ENV="${KERNEL_PYTHON_PREFIX}"
 else
     conda activate ${NB_PYTHON_PREFIX}
 fi

--- a/tests/conda/default-env/postBuild
+++ b/tests/conda/default-env/postBuild
@@ -1,0 +1,5 @@
+#!/bin/bash
+# install pytest with conda in the default env (should be $KERNEL_PYTHON_PREFIX)
+conda install -yq pytest
+# install there with pip (should be the same)
+pip install there

--- a/tests/conda/default-env/verify
+++ b/tests/conda/default-env/verify
@@ -1,0 +1,2 @@
+#!/bin/sh
+pytest -v ./verify.py

--- a/tests/conda/default-env/verify.py
+++ b/tests/conda/default-env/verify.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def test_sys_prefix():
+    # verify that pytest was installed in the notebook env
+    assert sys.prefix == os.environ["KERNEL_PYTHON_PREFIX"]
+
+
+def test_there():
+    # verify that there was installed in the notebook env
+    import there


### PR DESCRIPTION
so that `conda install` commands affect the kernel environment instead of the base env

This should preserve `conda install` behavior for Dockerfiles that inherit from r2d images.
This behavior is already managed at runtime by the ENTRYPOINT which properly activates the env.

cc @tam203 who reported the issue on gitter

I'm still testing this locally, and trying to think of a reasonable way to include an automated test for this.