### PR TITLE
[MRG] Update verification of Node install

### DIFF
--- a/tests/base/node10/verify
+++ b/tests/base/node10/verify
@@ -7,4 +7,4 @@ node --version | grep v10
 
 which npm
 npm --version
-npm --version | grep 6.4
+npm --version | grep 6.


### PR DESCRIPTION
Instead of checking the minor version as well only check the major version of npm.

This recently broke because the version that gets installed now is 6.9 not 6.4 any more.