### PR TITLE
add `git-lfs` to dockerfile used for the repo2docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN mkdir /tmp/wheelhouse \
 FROM python:${PYTHON_VERSION}-slim
 
 # we do need git, though
-RUN apt-get update \
- && apt-get -y install --no-install-recommends git \
+# git-lfs is in backports
+ARG DEB_RELEASE=stretch
+RUN echo "deb http://deb.debian.org/debian ${DEB_RELEASE}-backports main" > /etc/apt/sources.list.d/backports.list \
+ && apt-get update \
+ && apt-get -t ${DEB_RELEASE}-backports -y install --no-install-recommends git git-lfs \
  && rm -rf /var/lib/apt/lists/*
 
 # install repo2docker

--- a/tests/external/reproductions.repos.yaml
+++ b/tests/external/reproductions.repos.yaml
@@ -34,3 +34,8 @@
 - name: 10.5281/zenodo.1211089
   url: 10.5281/zenodo.1211089
   verify: python2 -c 'import matplotlib'
+# Test that files in git-lfs are properly cloned
+- name: LFS
+  url: https://github.com/binderhub-ci-repos/lfs
+  ref: 9abf54a
+  verify: grep "I am stored in git lfs" in-lfs.dat


### PR DESCRIPTION
ensures clones are in-tact when there are LFS-stored files.

Test repo added at binderhub-ci-repos/lfs

I don't think the test really covers this, since I think the tests don't use the repo2docker in the image, they use the local install.