### PR TITLE
[MRG] Generalize Zenodo content provider to support other Invenio repositories

### DIFF
--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -1,15 +1,16 @@
 import os
 import json
 import shutil
+import copy
 
 from os import makedirs
 from os import path
 from urllib.request import build_opener, urlopen, Request
 from zipfile import ZipFile, is_zipfile
-from idutils import normalize_doi, is_doi
 
 from .base import ContentProvider
 from ..utils import copytree
+from ..utils import normalize_doi, is_doi
 from .. import __version__
 
 
@@ -40,6 +41,24 @@ class Zenodo(ContentProvider):
         else:
             return doi
 
+    def _getfromdict(self, datadict, dotpath):
+        # Use a dotpath (string separated by periods)
+        # to access vaules in a dictionary
+        # data.files.0 returns value at dataDict[data][files][0]
+        split = dotpath.split(".")
+        # We check if we have any digits and convert these to
+        # ints for list access
+        mapList = []
+        for s in split:
+            if s.isdigit():
+                mapList.append(int(s))
+            else:
+                mapList.append(s)
+        values = copy.deepcopy(datadict)
+        for k in mapList:
+            values = values[k]
+        return values
+
     def detect(self, doi, ref=None, extra_args=None):
         """Trigger this provider for things that resolve to a Zenodo/Invenio record"""
         # We need the hostname (url where records are), api url (for metadata),
@@ -51,7 +70,7 @@ class Zenodo(ContentProvider):
                 "hostname": ["https://zenodo.org/record/", "http://zenodo.org/record/"],
                 "api": "https://zenodo.org/api/records/",
                 "filepath": "files",
-                "filename": "files.key",
+                "filename": "filename",
                 "download": "links.download",
                 "type": "metadata.upload_type",
             },
@@ -61,8 +80,9 @@ class Zenodo(ContentProvider):
                     "http://data.caltech.edu/records/",
                 ],
                 "api": "https://data.caltech.edu/api/record/",
-                "filepath": "files",
-                "filename": "electronic_location_and_access.electronic_name.0",
+                "filepath": "metadata.electronic_location_and_access",
+                "filename": "electronic_name.0",
+                "download": "uniform_resource_identifier",
                 "type": "metadata.resourceType.resourceTypeGeneral",
             },
         ]
@@ -91,8 +111,8 @@ class Zenodo(ContentProvider):
         def _fetch(file_ref, unzip=False):
             # the assumption is that `unzip=True` means that this is the only
             # file related to the zenodo record
-            with self._urlopen(file_ref["links"]["download"]) as src:
-                fname = file_ref["filename"]
+            with self._urlopen(self._getfromdict(file_ref, host["download"])) as src:
+                fname = self._getfromdict(file_ref, host["filename"])
                 if path.dirname(fname):
                     sub_dir = path.join(output_dir, path.dirname(fname))
                     if not path.exists(sub_dir):
@@ -126,9 +146,13 @@ class Zenodo(ContentProvider):
                         copytree(path.join(output_dir, d), output_dir)
                         shutil.rmtree(path.join(output_dir, d))
 
-        is_software = record["metadata"]["upload_type"] == "software"
-        only_one_file = len(record["files"]) == 1
-        for file_ref in record["files"]:
+        is_software = self._getfromdict(record, host["type"]).lower() == "software"
+        files = self._getfromdict(record, host["filepath"])
+
+        #
+
+        only_one_file = len(files) == 1
+        for file_ref in files:
             for line in _fetch(file_ref, unzip=is_software and only_one_file):
                 yield line
 

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -33,20 +33,10 @@ class Zenodo(ContentProvider):
         # Transform a DOI to a URL
         # If not a doi, assume we have a URL and return
         if is_doi(doi):
-            # Zenodo instances will most likely use DataCite DOIs
-            # Could also resolve the DOI to get the url
-            # Get url from DataCite
             doi = normalize_doi(doi)
 
-            req = Request(
-                "https://api.datacite.org/dois/{}".format(doi),
-                headers={"accept": "application/json"},
-            )
-            resp = self._urlopen(req)
-
-            record = json.loads(resp.read().decode("utf-8"))
-            url = record["data"]["attributes"]["url"]
-            return url
+            resp = self._urlopen("https://doi.org/{}".format(doi))
+            return resp.url
         else:
             return doi
 
@@ -78,11 +68,10 @@ class Zenodo(ContentProvider):
         ]
 
         url = self._process_doi(doi)
-        resp = self._urlopen(url)
-        self.record_id = resp.url.rsplit("/", maxsplit=1)[1]
 
         for host in hosts:
             if any([url.startswith(s) for s in host["hostname"]]):
+                self.record_id = url.rsplit("/", maxsplit=1)[1]
                 return {"record": self.record_id, "host": host}
 
     def fetch(self, spec, output_dir, yield_output=False):

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -30,22 +30,22 @@ class Zenodo(ContentProvider):
         return urlopen(req)
 
     def _process_doi(self, doi):
-        #Transform a DOI to a URL
-        #If not a doi, assume we have a URL and return
+        # Transform a DOI to a URL
+        # If not a doi, assume we have a URL and return
         if is_doi(doi):
-            #Zenodo instances will most likely use DataCite DOIs
-            #Could also resolve the DOI to get the url
-            #Get url from DataCite
+            # Zenodo instances will most likely use DataCite DOIs
+            # Could also resolve the DOI to get the url
+            # Get url from DataCite
             doi = normalize_doi(doi)
 
             req = Request(
-            "https://api.datacite.org/dois/{}".format(doi),
-            headers={"accept": "application/json"},
+                "https://api.datacite.org/dois/{}".format(doi),
+                headers={"accept": "application/json"},
             )
             resp = self._urlopen(req)
 
             record = json.loads(resp.read().decode("utf-8"))
-            url = record['data']['attributes']['url']
+            url = record["data"]["attributes"]["url"]
             return url
         else:
             return doi
@@ -55,24 +55,36 @@ class Zenodo(ContentProvider):
         # We need the hostname (url where records are), api url (for metadata),
         # filepath (path to files in metadata), filename (path to filename in
         # metadata), type (path to type in metadata)
-        
-        hosts = [{'hostname':["https://zenodo.org/record/","http://zenodo.org/record/"],
-            'api':'https://zenodo.org/api/records/','filepath':"files",
-            'filename':"files.key",'download':"links.download",
-            'type':"metadata.upload_type"},
-            {'hostname':["https://data.caltech.edu/records/","http://data.caltech.edu/records/"],
-            'api':"https://data.caltech.edu/api/record/",'filepath':"files",
-            'filename':"electronic_location_and_access.electronic_name.0",
-            'type':"metadata.resourceType.resourceTypeGeneral"}]
+
+        hosts = [
+            {
+                "hostname": ["https://zenodo.org/record/", "http://zenodo.org/record/"],
+                "api": "https://zenodo.org/api/records/",
+                "filepath": "files",
+                "filename": "files.key",
+                "download": "links.download",
+                "type": "metadata.upload_type",
+            },
+            {
+                "hostname": [
+                    "https://data.caltech.edu/records/",
+                    "http://data.caltech.edu/records/",
+                ],
+                "api": "https://data.caltech.edu/api/record/",
+                "filepath": "files",
+                "filename": "electronic_location_and_access.electronic_name.0",
+                "type": "metadata.resourceType.resourceTypeGeneral",
+            },
+        ]
 
         url = self._process_doi(doi)
         resp = self._urlopen(url)
         self.record_id = resp.url.rsplit("/", maxsplit=1)[1]
 
         for host in hosts:
-            if any([url.startswith(s) for s in host['hostname']]):
+            if any([url.startswith(s) for s in host["hostname"]]):
                 return {"record": self.record_id, "host": host}
-            
+
     def fetch(self, spec, output_dir, yield_output=False):
         """Fetch and unpack a Zenodo record"""
         record_id = spec["record"]
@@ -80,7 +92,7 @@ class Zenodo(ContentProvider):
 
         yield "Fetching Zenodo record {}.\n".format(record_id)
         req = Request(
-            "{}{}".format(host['api'],record_id),
+            "{}{}".format(host["api"], record_id),
             headers={"accept": "application/json"},
         )
         resp = self._urlopen(req)

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -29,7 +29,7 @@ class Zenodo(ContentProvider):
 
         return urlopen(req)
 
-    def _process_doi(self, doi):
+    def _doi2url(self, doi):
         # Transform a DOI to a URL
         # If not a doi, assume we have a URL and return
         if is_doi(doi):
@@ -67,7 +67,7 @@ class Zenodo(ContentProvider):
             },
         ]
 
-        url = self._process_doi(doi)
+        url = self._doi2url(doi)
 
         for host in hosts:
             if any([url.startswith(s) for s in host["hostname"]]):

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -6,6 +6,7 @@ from os import makedirs
 from os import path
 from urllib.request import build_opener, urlopen, Request
 from zipfile import ZipFile, is_zipfile
+from idutils import normalize_doi, is_doi
 
 from .base import ContentProvider
 from ..utils import copytree
@@ -28,39 +29,58 @@ class Zenodo(ContentProvider):
 
         return urlopen(req)
 
+    def _process_doi(self, doi):
+        #Transform a DOI to a URL
+        #If not a doi, assume we have a URL and return
+        if is_doi(doi):
+            #Zenodo instances will most likely use DataCite DOIs
+            #Could also resolve the DOI to get the url
+            #Get url from DataCite
+            doi = normalize_doi(doi)
+
+            req = Request(
+            "https://api.datacite.org/dois/{}".format(doi),
+            headers={"accept": "application/json"},
+            )
+            resp = self._urlopen(req)
+
+            record = json.loads(resp.read().decode("utf-8"))
+            url = record['data']['attributes']['url']
+            return url
+        else:
+            return doi
+
     def detect(self, doi, ref=None, extra_args=None):
-        """Trigger this provider for things that resolve to a Zenodo record"""
-        # To support Zenodo instances not hosted at zenodo.org we need to
-        # start maintaining a list of known DOI prefixes and their hostname.
-        # We should also change to returning a complete `record_url` that
-        # fetch() can use instead of constructing a URL there
-        doi = doi.lower()
-        # 10.5281 is the Zenodo DOI prefix
-        if doi.startswith("10.5281/"):
-            resp = self._urlopen("https://doi.org/{}".format(doi))
-            self.record_id = resp.url.rsplit("/", maxsplit=1)[1]
-            return {"record": self.record_id}
+        """Trigger this provider for things that resolve to a Zenodo/Invenio record"""
+        # We need the hostname (url where records are), api url (for metadata),
+        # filepath (path to files in metadata), filename (path to filename in
+        # metadata), type (path to type in metadata)
+        
+        hosts = [{'hostname':["https://zenodo.org/record/","http://zenodo.org/record/"],
+            'api':'https://zenodo.org/api/records/','filepath':"files",
+            'filename':"files.key",'download':"links.download",
+            'type':"metadata.upload_type"},
+            {'hostname':["https://data.caltech.edu/records/","http://data.caltech.edu/records/"],
+            'api':"https://data.caltech.edu/api/record/",'filepath':"files",
+            'filename':"electronic_location_and_access.electronic_name.0",
+            'type':"metadata.resourceType.resourceTypeGeneral"}]
 
-        elif doi.startswith("https://doi.org/10.5281/") or doi.startswith(
-            "http://doi.org/10.5281/"
-        ):
-            resp = self._urlopen(doi)
-            self.record_id = resp.url.rsplit("/", maxsplit=1)[1]
-            return {"record": self.record_id}
+        url = self._process_doi(doi)
+        resp = self._urlopen(url)
+        self.record_id = resp.url.rsplit("/", maxsplit=1)[1]
 
-        elif doi.startswith("https://zenodo.org/record/") or doi.startswith(
-            "http://zenodo.org/record/"
-        ):
-            self.record_id = doi.rsplit("/", maxsplit=1)[1]
-            return {"record": self.record_id}
-
+        for host in hosts:
+            if any([url.startswith(s) for s in host['hostname']]):
+                return {"record": self.record_id, "host": host}
+            
     def fetch(self, spec, output_dir, yield_output=False):
         """Fetch and unpack a Zenodo record"""
         record_id = spec["record"]
+        host = spec["host"]
 
         yield "Fetching Zenodo record {}.\n".format(record_id)
         req = Request(
-            "https://zenodo.org/api/records/{}".format(record_id),
+            "{}{}".format(host['api'],record_id),
             headers={"accept": "application/json"},
         )
         resp = self._urlopen(req)

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -393,22 +393,43 @@ def copytree(
     return dst
 
 
-# Code segments below from idutils (https://github.com/inveniosoftware/idutils)
+def deep_get(dikt, path):
+    """Get a value located in `path` from a nested dictionary.
+
+    Use a string separated by periods as the path to access
+    values in a nested dictionary:
+
+    deep_get(data, "data.files.0") == data["data"]["files"][0]
+    """
+    value = dikt
+    for component in path.split("."):
+        if component.isdigit():
+            value = value[int(component)]
+        else:
+            value = value[component]
+    return value
+
+
+# doi_regexp, is_doi, and normalize_doi are from idutils (https://github.com/inveniosoftware/idutils)
 # Copyright (C) 2015-2018 CERN.
 # Copyright (C) 2018 Alan Rubin.
 # Licensed under BSD-3-Clause license
 doi_regexp = re.compile(
     "(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.+)$", flags=re.I
 )
-"""See http://en.wikipedia.org/wiki/Digital_object_identifier."""
 
 
 def is_doi(val):
-    """Test if argument is a DOI."""
+    """Returns None if val doesn't match pattern of a DOI.
+    http://en.wikipedia.org/wiki/Digital_object_identifier."""
+    print(type(val))
+    print(val)
     return doi_regexp.match(val)
 
 
 def normalize_doi(val):
-    """Normalize a DOI."""
+    """Return just the DOI (e.g. 10.1234/jshd123)
+    from a val that could include a url or doi 
+    (e.g. https://doi.org/10.1234/jshd123)"""
     m = doi_regexp.match(val)
     return m.group(2)

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -391,3 +391,24 @@ def copytree(
     if errors:
         raise Error(errors)
     return dst
+
+
+# Code segments below from idutils (https://github.com/inveniosoftware/idutils)
+# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2018 Alan Rubin.
+# Licensed under BSD-3-Clause license
+doi_regexp = re.compile(
+    "(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.+)$", flags=re.I
+)
+"""See http://en.wikipedia.org/wiki/Digital_object_identifier."""
+
+
+def is_doi(val):
+    """Test if argument is a DOI."""
+    return doi_regexp.match(val)
+
+
+def normalize_doi(val):
+    """Normalize a DOI."""
+    m = doi_regexp.match(val)
+    return m.group(2)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "ruamel.yaml>=0.15",
         "toml",
         "semver",
-        "idutils"
+        "idutils",
     ],
     python_requires=">=3.5",
     author="Project Jupyter Contributors",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "ruamel.yaml>=0.15",
         "toml",
         "semver",
-        "idutils",
     ],
     python_requires=">=3.5",
     author="Project Jupyter Contributors",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "ruamel.yaml>=0.15",
         "toml",
         "semver",
+        "idutils"
     ],
     python_requires=">=3.5",
     author="Project Jupyter Contributors",

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -50,7 +50,7 @@ def test_detect():
         fake_urlopen.return_value.url = "https://data.caltech.edu/records/1235"
         # valid CaltechDATA DOIs trigger this content provider
         assert Zenodo().detect("10.22002/d1.1235") == {
-            "hots": {
+            "host": {
                 "hostname": [
                     "https://data.caltech.edu/records/",
                     "http://data.caltech.edu/records/",

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -64,7 +64,7 @@ def test_detect():
             "record": "1235",
         }
         assert Zenodo().detect("https://doi.org/10.22002/d1.1235")["record"] == "1235"
-        assert Zenodo().detect("https://zenodo.org/record/3232985")["record"] == "1235"
+        assert Zenodo().detect("https://data.caltech.edu/records/1235")["record"] == "1235"
 
         # only two of the three calls above have to resolve a DOI
         assert fake_urlopen.call_count == 2

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -82,3 +82,31 @@ def test_invalid_port_mapping(port_spec):
         utils.validate_and_generate_port_mapping([port_spec])
 
     assert 'Port specification "{}"'.format(port_spec) in str(e.value)
+
+
+def test_deep_get():
+    data = {"data": {"files": [1, 2, 3]}}
+    assert utils.deep_get(data, "data.files.0") == 1
+    assert utils.deep_get(data, "data.files.1") == 2
+    assert utils.deep_get(data, "data.files") == [1, 2, 3]
+    assert utils.deep_get(data, "data") == {"files": [1, 2, 3]}
+
+
+def test_is_doi():
+    assert utils.is_doi("10.1234/jshd123") != None
+    assert utils.is_doi("10.1234/JSHD.8192") != None
+    assert utils.is_doi("doi.org/10.1234/jshd123") != None
+    assert utils.is_doi("http://doi.org/10.1234/jshd123") != None
+    assert utils.is_doi("https://doi.org/10.1234/jshd123") != None
+    assert utils.is_doi("http://dx.doi.org/10.1234/jshd123") != None
+    assert utils.is_doi("101234/jshd123") == None
+    assert utils.is_doi("https://mybinder.org") == None
+
+
+def test_normalize_doi():
+    assert utils.normalize_doi("10.1234/jshd123") == "10.1234/jshd123"
+    assert utils.normalize_doi("10.1234/JSHD.8192") == "10.1234/JSHD.8192"
+    assert utils.normalize_doi("doi.org/10.1234/jshd123") == "10.1234/jshd123"
+    assert utils.normalize_doi("http://doi.org/10.1234/jshd123") == "10.1234/jshd123"
+    assert utils.normalize_doi("https://doi.org/10.1234/jshd123") == "10.1234/jshd123"
+    assert utils.normalize_doi("http://dx.doi.org/10.1234/jshd123") == "10.1234/jshd123"


### PR DESCRIPTION
Updates the Zenodo content provider to:

- Use a more general DOI -> URL conversion
- Support different hosts and different metadata organizations

My interest is supporting CaltechDATA, which is based on Zenodo but has a different metadata scheme.  I'll also work on getting Binder buttons into CaltechDATA, which would be cool.

I'm still working on figuring out how to generalize the object path stuff.  The idutils functions could also be copied into utils; don't know what your preference is on dependencies.  Any and all suggestions are appreciated!
