### PR TITLE
base docker image on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,19 @@
-ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}
+ARG ALPINE_VERSION=3.9.4
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache git python3 python3-dev
 
 # build wheels in first image
 ADD . /tmp/src
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
+ && pip3 install wheel \
  && pip3 wheel --no-cache-dir /tmp/src
 
-# run with slim variant instead of full
-# since we won't need compilers and friends
-FROM python:${PYTHON_VERSION}-slim
+FROM alpine:${ALPINE_VERSION}
 
-# we do need git, though
-# git-lfs is in backports
-ARG DEB_RELEASE=stretch
-RUN echo "deb http://deb.debian.org/debian ${DEB_RELEASE}-backports main" > /etc/apt/sources.list.d/backports.list \
- && apt-get update \
- && apt-get -t ${DEB_RELEASE}-backports -y install --no-install-recommends git git-lfs \
- && rm -rf /var/lib/apt/lists/*
+# install python, git
+RUN apk add --no-cache git git-lfs python3
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse


### PR DESCRIPTION
for a much smaller image (93 vs 231 MB) and faster builds.

The issue that prevented us from using alpine (#160) has since been resolved.