### PR TITLE
Use the `strict` config option for conda

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -30,6 +30,7 @@ export PATH="${CONDA_DIR}/bin:$PATH"
 
 # Allow easy direct installs from conda forge
 conda config --system --add channels conda-forge
+conda config --set channel_priority strict
 
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false


### PR DESCRIPTION
Conda will be adopting `strict` as the default option soon but until then it is recommend to enable it when using third party channel like conda-forge. For a longer explanation see https://youtu.be/9Ft20NizQA4?t=930.

The gist of it is:
- env/install solutions will be faster;
- the stack of packages are consistent "within the ecosystem" and errors are easier to debug;
- [avoid the mixing channel problem](https://conda-forge.org/docs/user/tipsandtricks.html#using-multiple-channels).

Ping @jhamman 