### PR TITLE
updated link for the community edition of docker

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ Prerequisite: Docker
 
 Install `Docker <https://www.docker.com>`_ as it is required
 to build Docker images. The
-`Community Edition <https://www.docker.com/community-edition>`_,
+`Community Edition <https://docs.docker.com/install/>`_,
 is available for free.
 
 Recent versions of Docker are recommended.


### PR DESCRIPTION
The install instructions pointed to an outdated link for the community edition of docker. I have updated the link to point to https://docs.docker.com/install/.

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
