### PR TITLE
Reading Docker timeout value from environment variable

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,8 @@ New features
   to Python 3.5 in :pr:`684` by :user:`betatim`.
 - Support for `Pipfile` and `Pipfile.lock` implemented in :pr:`649` by
   :user:`consideratio`.
+- Add an environment variable `REPO2DOCKER_DOCKER_TIMEOUT` to configure the timeout (in seconds)
+  on the docker push timeout in :pr:`717` by :user:`mael-le-gal`
 
 API changes
 -----------

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import docker
 import escapism
+import os
 
 from repo2docker.app import Repo2Docker
 from repo2docker.__main__ import make_r2d
@@ -121,3 +122,17 @@ def test_root_not_allowed():
             builds.return_value = []
             app.build()
         builds.assert_called_once()
+
+
+def test_get_timeout():
+    app = Repo2Docker()
+    timeout = app._get_timeout()
+    assert 60 == timeout
+
+    os.environ["REPO2DOCKER_DOCKER_TIMEOUT"] = "100"
+    timeout = app._get_timeout()
+    assert 100 == timeout
+
+    os.environ["REPO2DOCKER_DOCKER_TIMEOUT"] = "toto"
+    with pytest.raises(ValueError):
+        app._get_timeout()


### PR DESCRIPTION
Fixing the following [issue](https://github.com/jupyter/repo2docker/issues/711) by adding `DOCKER_REGISTRY_TIMEOUT` environment variable 