### PR TITLE
[WIP] Version bump Conda from 4.6.14 to 4.7.5

### DIFF
--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -22,7 +22,7 @@ from ruamel.yaml import YAML
 # Docker image version can be different than conda version,
 # since miniconda3 docker images seem to lag conda releases.
 MINICONDA_DOCKER_VERSION = "4.5.12"
-CONDA_VERSION = "4.6.14"
+CONDA_VERSION = "4.7.5"
 
 HERE = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -28,9 +28,6 @@ fi
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
-# Allow easy direct installs from conda forge
-conda config --system --add channels conda-forge
-
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.6.14
-CONDA_VERSION=4.6.14
+CONDA_VERSION=4.7.5
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
 MD5SUM="718259965f234088d785cad1fbd7de03"

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -35,6 +35,11 @@ conda config --system --add channels conda-forge
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true
 
+# conda 4.7 the free channel was removed from defaults; this adds it back while 
+# maintaining correct channel priority (required for the Xeus-Cling test in 
+# test/external/reproductions.repos.yaml to pass) 
+conda config --set restore_free_channel true
+
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -28,6 +28,9 @@ fi
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
+# Allow easy direct installs from conda forge
+conda config --system --add channels conda-forge
+
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -43,6 +43,8 @@ if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
     conda install -yq conda==${CONDA_VERSION}
 fi
 
+conda config --system --set channel_priority "strict"
+
 echo "installing notebook env:"
 cat /tmp/environment.yml
 conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -35,11 +35,6 @@ conda config --system --add channels conda-forge
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true
 
-# conda 4.7 the free channel was removed from defaults; this adds it back while 
-# maintaining correct channel priority (required for the Xeus-Cling test in 
-# test/external/reproductions.repos.yaml to pass) 
-conda config --system --set restore_free_channel true
-
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 
@@ -47,6 +42,11 @@ echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
     conda install -yq conda==${CONDA_VERSION}
 fi
+
+# conda 4.7 the free channel was removed from defaults; this adds it back while 
+# maintaining correct channel priority (required for the Xeus-Cling test in 
+# test/external/reproductions.repos.yaml to pass) 
+conda config --system --set restore_free_channel true
 
 echo "installing notebook env:"
 cat /tmp/environment.yml

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -40,7 +40,8 @@ if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
     conda install -yq conda==${CONDA_VERSION}
 fi
 
-conda config --system --set channel_priority "strict"
+# avoid future changes to default channel_priority behavior
+conda config --system --set channel_priority "flexible"
 
 echo "installing notebook env:"
 cat /tmp/environment.yml

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -38,7 +38,7 @@ conda config --system --set show_channel_urls true
 # conda 4.7 the free channel was removed from defaults; this adds it back while 
 # maintaining correct channel priority (required for the Xeus-Cling test in 
 # test/external/reproductions.repos.yaml to pass) 
-conda config --set restore_free_channel true
+conda config --system --set restore_free_channel true
 
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -43,11 +43,6 @@ if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
     conda install -yq conda==${CONDA_VERSION}
 fi
 
-# conda 4.7 the free channel was removed from defaults; this adds it back while 
-# maintaining correct channel priority (required for the Xeus-Cling test in 
-# test/external/reproductions.repos.yaml to pass) 
-conda config --system --set restore_free_channel true
-
 echo "installing notebook env:"
 cat /tmp/environment.yml
 conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,6 +5,6 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["conda", "--version"]).decode("utf8").strip()
-assert out == "conda 4.6.14", out
+assert out == "conda 4.7.5", out
 
 import numpy


### PR DESCRIPTION
Conda 4.7.5 was [released yesterday](https://www.anaconda.com/how-we-made-conda-faster-4-7/). This PR bumps the Conda version from 4.6.14 to 4.7.5. Note that a new version of Miniconda has not yet been released. I will bump that version number as well if a newer version is released before this PR is merged.

This is my first PR and I did my best to identify all possible locations where the Conda version number was explicitly specified. I only found two in `repo2docker/buildpacks/conda` directory.