### PR TITLE
[MRG] Handle root user case more gracefully. Fixes #696

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -303,6 +303,16 @@ def make_r2d(argv=None):
         r2d.user_id = args.user_id
     if args.user_name:
         r2d.user_name = args.user_name
+    if r2d.user_id == 0 and not r2d.dry_run:
+        print("Root as the primary user in the image is not permitted.")
+        print(
+            "The uid and the username of the user invoking repo2docker "
+            "is used to create a mirror account in the image by default. "
+            "To override that behavior pass --user-id <numeric_id> and "
+            " --user-name <string> to repo2docker.\n"
+            "Please see repo2docker --help for more details.\n"
+        )
+        sys.exit(1)
 
     if args.build_memory_limit:
         # if the string only contains numerals we assume it should be an int

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -7,7 +7,6 @@ Usage:
 
     python -m repo2docker https://github.com/you/your-repo
 """
-import errno
 import json
 import sys
 import logging
@@ -670,17 +669,9 @@ class Repo2Docker(Application):
 
                 if not self.dry_run:
                     if self.user_id == 0:
-                        self.log.error(
-                            "Root as the primary user in the image is not permitted.\n"
+                        raise ValueError(
+                            "Root as the primary user in the image is not permitted."
                         )
-                        self.log.info(
-                            "The uid and the username of the user invoking repo2docker "
-                            "is used to create a mirror account in the image by default. "
-                            "To override that behavior pass --user-id <numeric_id> and "
-                            " --user-name <string> to repo2docker.\n"
-                            "Please see repo2docker --help for more details.\n"
-                        )
-                        sys.exit(errno.EPERM)
 
                     build_args = {
                         "NB_USER": self.user_name,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -110,10 +110,13 @@ def test_root_not_allowed():
     with TemporaryDirectory() as src, patch("os.geteuid") as geteuid:
         geteuid.return_value = 0
         argv = [src]
-        app = make_r2d(argv)
         with pytest.raises(SystemExit) as exc:
+            app = make_r2d(argv)
+            assert exc.code == 1
+
+        with pytest.raises(ValueError):
+            app = Repo2Docker(repo=src, run=False)
             app.build()
-            assert exc.code == errno.EPERM
 
         app = Repo2Docker(repo=src, user_id=1000, user_name="jovyan", run=False)
         app.initialize()


### PR DESCRIPTION
Trying to atone for bugs introduced by #679. With this PR exiting happens only when r2d is invoked from the commandline. In case user tries to use r2d as library, `ValueError` is raised instead.