### PR TITLE
[Pipfile] --ignore-installed to the install command

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,8 @@ Bug fixes
 ---------
 - Prevent building the image as root if --user-id and --user-name are not specified
   in :pr:`676` by :user:`Xarthisius`.
+- Make Pipfile.lock installs more reliable with pip's --ignore-installed in :pr:`649` by
+  :user:`consideratio`.
 
 
 Version 0.9.0

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -128,11 +128,16 @@ class PipfileBuildPack(CondaBuildPack):
         #   Dockerfile where this later is read within, will thanks to the '\'
         #   let the RUN command continue on the next line. So it is only added
         #   to avoid forcing us to write it all on a single line.
+        # - PIP_IGNORE_INSTALLED was added to influence the underlying use of
+        #   pip in a way that allows us to overcome issues with preinstaleld
+        #   parts in the environment that could not be uninstalled. For more
+        #   details, see https://github.com/jupyter/repo2docker/issues/725.
         assemble_scripts.append(
             (
                 "${NB_USER}",
                 """(cd {working_directory} && \\
                     PATH="${{KERNEL_PYTHON_PREFIX}}/bin:$PATH" \\
+                    PIP_IGNORE_INSTALLED=1 \\
                         pipenv install {install_option} --system --dev \\
                 )""".format(
                     working_directory=working_directory,


### PR DESCRIPTION
Fixes #725

While I'm confident this is appreciated overall by users of the PipfileBuildPack, as it can make it become usable as compared to unusable, but I'm not confident it comes without drawbacks.

It would be good to have someone evaluate the consequences of adding the `--ignore-installed` flag to `pip` that is used by `pipenv` for the PipfileBuildPackage?