### PR TITLE
include full docker progress events in push progress events

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -457,6 +457,8 @@ class Repo2Docker(Application):
         layers = {}
         last_emit_time = time.time()
         for chunk in client.push(self.output_image_spec, stream=True):
+            # each chunk can be one or more lines of json events
+            # split lines here in case multiple are delivered at once
             for line in chunk.splitlines():
                 line = line.decode("utf-8", errors="replace")
                 try:
@@ -478,11 +480,10 @@ class Repo2Docker(Application):
                 layers[progress["id"]] = progress
                 if time.time() - last_emit_time > 1.5:
                     self.log.info(
-                        "Pushing image\n", extra=dict(
-                            progress=progress_layers,
-                            layers=layers,
-                            phase="pushing",
-                        )
+                        "Pushing image\n",
+                        extra=dict(
+                            progress=progress_layers, layers=layers, phase="pushing"
+                        ),
                     )
                     last_emit_time = time.time()
         self.log.info(


### PR DESCRIPTION
for backward-compatibility, add a `layers` key with the full data,
preserving the `progress` field, which has only partial data, depending on state of each layer.

The most useful field, I think, is `progress`, which shows the docker cli-rendered progress bar.

Strangely, when I sampled the log data we get from ovh, current and total in progressDetail (which we already publish under 'progress') were on totally different scales,
so rendering our own progress bars with `$current/$total` doesn't seem trustworthy. Not sure what's up with that.

Sample log data:

```json
  "layers": {
    "25b373f5f7f1": {
      "status": "Waiting",
      "progressDetail": {},
      "id": "25b373f5f7f1"
    },
    "e9f2b5eca21e": {
      "status": "Pushing",
      "progressDetail": {
        "current": 747589632,
        "total": 758965327
      },
      "progress": "[=================================================> ]  747.6MB/759MB",
      "id": "e9f2b5eca21e"
    },
    "7753d7e0913b": {
      "status": "Pushed",
      "progressDetail": {},
      "id": "7753d7e0913b"
    },
    "ed03b06eb165": {
      "status": "Pushed",
      "progressDetail": {},
      "id": "ed03b06eb165"
    },
    "01cb88e6c1af": {
      "status": "Pushed",
      "progressDetail": {},
      "id": "01cb88e6c1af"
    },
    "adda4de99b3d": {
      "status": "Mounted from library/buildpack-deps",
      "progressDetail": {},
      "id": "adda4de99b3d"
    },
    "3a034154b7b6": {
      "status": "Mounted from library/buildpack-deps",
      "progressDetail": {},
      "id": "3a034154b7b6"
    }
```

Related to https://github.com/jupyterhub/binderhub/issues/852 . Passing through the `progress` fields might be the easiest implementation.