### PR TITLE
[MRG] switch pip packages to conda-forge in conda buildpack

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -32,10 +32,10 @@ Below is a list of supported configuration files (roughly in the order of build 
 ``environment.yml`` is the standard configuration file used by `conda <https://conda.io>`_
 that lets you install any kind of package,
 including Python, R, and C/C++ packages.
-``repo2docker`` does not use ``environment.yml`` to create and activate a new conda environment.
-Rather, it updates a base conda environment with the packages listed in ``environment.yml``.
+``repo2docker`` does not use your ``environment.yml`` to create and activate a new conda environment.
+Rather, it updates a base conda environment `defined here <https://github.com/jupyter/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml>`_ with the packages listed in your ``environment.yml``.
 This means that the environment will always have the same default name, not the name
-specified in ``environment.yml``.
+specified in your ``environment.yml``.
 
 .. note::
 

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-07-16 13:18:20 UTC
+# Frozen on 2019-07-29 15:52:07 UTC
 name: r2d
 channels:
   - conda-forge
@@ -7,17 +7,27 @@ channels:
   - conda-forge/label/broken
 dependencies:
   - _libgcc_mutex=0.1=main
+  - alembic=1.0.11=py_0
+  - asn1crypto=0.24.0=py37_1003
+  - async_generator=1.10=py_0
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
+  - blinker=1.4=py_1
   - bzip2=1.0.8=h516909a_0
   - ca-certificates=2019.6.16=hecc5488_0
   - certifi=2019.6.16=py37_1
+  - certipy=0.1.3=py_0
+  - cffi=1.12.3=py37h8022711_0
+  - chardet=3.0.4=py37_1003
+  - configurable-http-proxy=4.1.0=node11_1
+  - cryptography=2.7=py37h72c5cf5_0
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py37_1000
+  - idna=2.8=py37_1000
   - ipykernel=5.1.1=py37h5ca1d4c_0
-  - ipython=7.6.1=py37h5ca1d4c_0
+  - ipython=7.7.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
   - jedi=0.14.1=py37_0
@@ -25,43 +35,62 @@ dependencies:
   - jsonschema=3.0.1=py37_0
   - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
+  - jupyterhub=1.0.0=py37_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
+  - krb5=1.16.3=h05b26f9_1001
+  - libcurl=7.65.3=hda55be3_0
+  - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
   - libsodium=1.0.17=h516909a_0
+  - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.1.0=hdf63c60_0
+  - mako=1.0.10=py_0
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=11.14.0=he1b5a44_1
   - notebook=5.7.8=py37_1
+  - nteract_on_jupyter=2.0.12=py_0
+  - oauthlib=3.0.1=py_0
   - openssl=1.1.1c=h516909a_0
+  - pamela=1.0.0=py_0
   - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
   - parso=0.5.1=py_0
   - pexpect=4.7.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.1.1=py37_0
+  - pip=19.2.1=py37_0
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
+  - pycparser=2.19=py37_1
+  - pycurl=7.43.0.2=py37h16ce93b_1
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.3=py37h516909a_0
+  - pyjwt=1.7.1=py_0
+  - pyopenssl=19.0.0=py37_0
+  - pyrsistent=0.15.4=py37h516909a_0
+  - pysocks=1.7.0=py37_0
   - python=3.7.3=h33d41f4_1
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.2=py37hc4ba49a_1
+  - python-editor=1.0.4=py_0
+  - pyzmq=18.0.2=py37h1768529_2
   - readline=8.0=hf8c457e_0
+  - requests=2.22.0=py37_1
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py37_0
   - six=1.12.0=py37_1000
+  - sqlalchemy=1.3.6=py37h516909a_0
   - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
   - tk=8.6.9=hed695b0_1002
   - tornado=6.0.3=py37h516909a_0
   - traitlets=4.3.2=py37_1000
+  - urllib3=1.25.3=py37_0
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py37_0
@@ -69,25 +98,5 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1005
-  - pip:
-    - alembic==1.0.11
-    - asn1crypto==0.24.0
-    - async-generator==1.10
-    - certipy==0.1.3
-    - cffi==1.12.3
-    - chardet==3.0.4
-    - cryptography==2.7
-    - idna==2.8
-    - jupyterhub==1.0.0
-    - mako==1.0.13
-    - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.2
-    - pamela==1.0.0
-    - pycparser==2.19
-    - pyopenssl==19.0.0
-    - python-editor==1.0.4
-    - requests==2.22.0
-    - sqlalchemy==1.3.5
-    - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-07-16 13:14:12 UTC
+# Frozen on 2019-07-29 15:49:47 UTC
 name: r2d
 channels:
   - conda-forge
@@ -14,7 +14,7 @@ dependencies:
   - certifi=2019.6.16=py27_1
   - decorator=4.4.0=py_0
   - enum34=1.1.6=py27_1001
-  - futures=3.2.0=py27_1000
+  - futures=3.3.0=py27_0
   - ipykernel=4.8.2=py27_0
   - ipython=5.8.0=py27_0
   - ipython_genutils=0.2.0=py_1
@@ -29,13 +29,13 @@ dependencies:
   - pathlib2=2.3.4=py27_0
   - pexpect=4.7.0=py27_0
   - pickleshare=0.7.5=py27_1000
-  - pip=19.1.1=py27_0
+  - pip=19.2.1=py27_0
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py_1001
   - pygments=2.4.2=py_0
   - python=2.7.15=h5a48372_1009
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.2=py27hc4ba49a_1
+  - pyzmq=18.0.2=py27h1768529_2
   - readline=8.0=hf8c457e_0
   - scandir=1.10.0=py27h14c3975_0
   - setuptools=41.0.1=py27_0

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-07-16 13:15:56 UTC
+# Frozen on 2019-07-29 15:50:44 UTC
 name: r2d
 channels:
   - conda-forge
@@ -7,16 +7,26 @@ channels:
   - conda-forge/label/broken
 dependencies:
   - _libgcc_mutex=0.1=main
+  - alembic=1.0.11=py_0
+  - asn1crypto=0.24.0=py36_1003
+  - async_generator=1.10=py_0
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
+  - blinker=1.4=py_1
   - ca-certificates=2019.6.16=hecc5488_0
   - certifi=2019.6.16=py36_1
+  - certipy=0.1.3=py_0
+  - cffi=1.12.3=py36h8022711_0
+  - chardet=3.0.4=py36_1003
+  - configurable-http-proxy=4.1.0=node11_1
+  - cryptography=2.7=py36h72c5cf5_0
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py36_1000
+  - idna=2.8=py36_1000
   - ipykernel=5.1.1=py36h5ca1d4c_0
-  - ipython=7.6.1=py36h5ca1d4c_0
+  - ipython=7.7.0=py36h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
   - jedi=0.14.1=py36_0
@@ -24,43 +34,62 @@ dependencies:
   - jsonschema=3.0.1=py36_0
   - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
+  - jupyterhub=1.0.0=py36_0
   - jupyterlab=0.35.4=py36_0
   - jupyterlab_server=0.2.0=py_0
+  - krb5=1.16.3=h05b26f9_1001
+  - libcurl=7.65.3=hda55be3_0
+  - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
   - libsodium=1.0.17=h516909a_0
+  - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.1.0=hdf63c60_0
+  - mako=1.0.10=py_0
   - markupsafe=1.1.1=py36h14c3975_0
   - mistune=0.8.4=py36h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=11.14.0=he1b5a44_1
   - notebook=5.7.8=py36_1
+  - nteract_on_jupyter=2.0.12=py_0
+  - oauthlib=3.0.1=py_0
   - openssl=1.1.1c=h516909a_0
+  - pamela=1.0.0=py_0
   - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
   - parso=0.5.1=py_0
   - pexpect=4.7.0=py36_0
   - pickleshare=0.7.5=py36_1000
-  - pip=19.1.1=py36_0
+  - pip=19.2.1=py36_0
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
+  - pycparser=2.19=py36_1
+  - pycurl=7.43.0.2=py36h16ce93b_1
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.3=py36h516909a_0
+  - pyjwt=1.7.1=py_0
+  - pyopenssl=19.0.0=py36_0
+  - pyrsistent=0.15.4=py36h516909a_0
+  - pysocks=1.7.0=py36_0
   - python=3.6.7=h357f687_1005
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.2=py36hc4ba49a_1
+  - python-editor=1.0.4=py_0
+  - pyzmq=18.0.2=py36h1768529_2
   - readline=8.0=hf8c457e_0
+  - requests=2.22.0=py36_1
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py36_0
   - six=1.12.0=py36_1000
+  - sqlalchemy=1.3.6=py36h516909a_0
   - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py36_0
   - testpath=0.4.2=py_1001
   - tk=8.6.9=hed695b0_1002
   - tornado=6.0.3=py36h516909a_0
   - traitlets=4.3.2=py36_1000
+  - urllib3=1.25.3=py36_0
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py36_0
@@ -68,25 +97,5 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1005
-  - pip:
-    - alembic==1.0.11
-    - asn1crypto==0.24.0
-    - async-generator==1.10
-    - certipy==0.1.3
-    - cffi==1.12.3
-    - chardet==3.0.4
-    - cryptography==2.7
-    - idna==2.8
-    - jupyterhub==1.0.0
-    - mako==1.0.13
-    - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.2
-    - pamela==1.0.0
-    - pycparser==2.19
-    - pyopenssl==19.0.0
-    - python-editor==1.0.4
-    - requests==2.22.0
-    - sqlalchemy==1.3.5
-    - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,11 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-07-16 13:15:56 UTC
+# Generated on 2019-07-29 15:50:44 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.4.2
 - jupyterlab==0.35.4
+- jupyterhub=1.0
 - nbconvert==5.4.1
 - notebook==5.7.8
-- pip:
-  - nteract_on_jupyter==2.0.12
-  - jupyterhub==1.0.*
+- nteract_on_jupyter==2.0.12

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-07-16 13:18:20 UTC
+# Frozen on 2019-07-29 15:52:07 UTC
 name: r2d
 channels:
   - conda-forge
@@ -7,17 +7,27 @@ channels:
   - conda-forge/label/broken
 dependencies:
   - _libgcc_mutex=0.1=main
+  - alembic=1.0.11=py_0
+  - asn1crypto=0.24.0=py37_1003
+  - async_generator=1.10=py_0
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
+  - blinker=1.4=py_1
   - bzip2=1.0.8=h516909a_0
   - ca-certificates=2019.6.16=hecc5488_0
   - certifi=2019.6.16=py37_1
+  - certipy=0.1.3=py_0
+  - cffi=1.12.3=py37h8022711_0
+  - chardet=3.0.4=py37_1003
+  - configurable-http-proxy=4.1.0=node11_1
+  - cryptography=2.7=py37h72c5cf5_0
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py37_1000
+  - idna=2.8=py37_1000
   - ipykernel=5.1.1=py37h5ca1d4c_0
-  - ipython=7.6.1=py37h5ca1d4c_0
+  - ipython=7.7.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
   - jedi=0.14.1=py37_0
@@ -25,43 +35,62 @@ dependencies:
   - jsonschema=3.0.1=py37_0
   - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
+  - jupyterhub=1.0.0=py37_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
+  - krb5=1.16.3=h05b26f9_1001
+  - libcurl=7.65.3=hda55be3_0
+  - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
   - libsodium=1.0.17=h516909a_0
+  - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.1.0=hdf63c60_0
+  - mako=1.0.10=py_0
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
+  - nodejs=11.14.0=he1b5a44_1
   - notebook=5.7.8=py37_1
+  - nteract_on_jupyter=2.0.12=py_0
+  - oauthlib=3.0.1=py_0
   - openssl=1.1.1c=h516909a_0
+  - pamela=1.0.0=py_0
   - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
   - parso=0.5.1=py_0
   - pexpect=4.7.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.1.1=py37_0
+  - pip=19.2.1=py37_0
   - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
+  - pycparser=2.19=py37_1
+  - pycurl=7.43.0.2=py37h16ce93b_1
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.3=py37h516909a_0
+  - pyjwt=1.7.1=py_0
+  - pyopenssl=19.0.0=py37_0
+  - pyrsistent=0.15.4=py37h516909a_0
+  - pysocks=1.7.0=py37_0
   - python=3.7.3=h33d41f4_1
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.2=py37hc4ba49a_1
+  - python-editor=1.0.4=py_0
+  - pyzmq=18.0.2=py37h1768529_2
   - readline=8.0=hf8c457e_0
+  - requests=2.22.0=py37_1
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py37_0
   - six=1.12.0=py37_1000
+  - sqlalchemy=1.3.6=py37h516909a_0
   - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
   - tk=8.6.9=hed695b0_1002
   - tornado=6.0.3=py37h516909a_0
   - traitlets=4.3.2=py37_1000
+  - urllib3=1.25.3=py37_0
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py37_0
@@ -69,25 +98,5 @@ dependencies:
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1005
-  - pip:
-    - alembic==1.0.11
-    - asn1crypto==0.24.0
-    - async-generator==1.10
-    - certipy==0.1.3
-    - cffi==1.12.3
-    - chardet==3.0.4
-    - cryptography==2.7
-    - idna==2.8
-    - jupyterhub==1.0.0
-    - mako==1.0.13
-    - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.2
-    - pamela==1.0.0
-    - pycparser==2.19
-    - pyopenssl==19.0.0
-    - python-editor==1.0.4
-    - requests==2.22.0
-    - sqlalchemy==1.3.5
-    - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,11 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-07-16 13:18:20 UTC
+# Generated on 2019-07-29 15:52:07 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.4.2
 - jupyterlab==0.35.4
+- jupyterhub=1.0
 - nbconvert==5.4.1
 - notebook==5.7.8
-- pip:
-  - nteract_on_jupyter==2.0.12
-  - jupyterhub==1.0.*
+- nteract_on_jupyter==2.0.12

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,8 +1,8 @@
 dependencies:
-  - python=3.7.*
+  - python=3.7
   - ipywidgets==7.4.2
   - jupyterlab==0.35.4
+  - jupyterhub=1.0
   - nbconvert==5.4.1
   - notebook==5.7.8
-  - jupyterhub=1.0.*
-  - nteract_on_jupyter=2.0.12
+  - nteract_on_jupyter==2.0.12

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -4,6 +4,5 @@ dependencies:
   - jupyterlab==0.35.4
   - nbconvert==5.4.1
   - notebook==5.7.8
-  - pip:
-    - nteract_on_jupyter==2.0.12
-    - jupyterhub==1.0.*
+  - jupyterhub=1.0.*
+  - nteract_on_jupyter=2.0.12

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -22,7 +22,7 @@ from ruamel.yaml import YAML
 # Docker image version can be different than conda version,
 # since miniconda3 docker images seem to lag conda releases.
 MINICONDA_DOCKER_VERSION = "4.5.12"
-CONDA_VERSION = "4.7.5"
+CONDA_VERSION = "4.7.10"
 
 HERE = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.6.14
-CONDA_VERSION=4.7.5
+CONDA_VERSION=4.7.10
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
 MD5SUM="718259965f234088d785cad1fbd7de03"
@@ -55,9 +55,6 @@ conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 # which we don't intend.
 # this file must not be *removed*, however
 echo '' > ${NB_PYTHON_PREFIX}/conda-meta/history
-
-# enable nteract-on-jupyter, which was installed with pip
-jupyter serverextension enable nteract_on_jupyter --sys-prefix
 
 if [[ -f /tmp/kernel-environment.yml ]]; then
     # install kernel env and register kernelspec

--- a/tests/base/node10/verify
+++ b/tests/base/node10/verify
@@ -1,9 +1,13 @@
 #!/bin/sh
 
 set -e
+# check node from conda-forge
 which node
 node --version
-node --version | grep v10
+node --version | grep v11
+# check node system package
+/usr/bin/node --version
+/usr/bin/node --version | grep v10
 
 which npm
 npm --version

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,6 +5,6 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["conda", "--version"]).decode("utf8").strip()
-assert out == "conda 4.7.5", out
+assert out == "conda 4.7.10", out
 
 import numpy


### PR DESCRIPTION
This pull request modifies the conda buildpack to install `jupyterhub` and `nteract_on_jupyter` from conda-forge instead of pip. 

According to @ocefpaf "this can lead to dependencies installed with conda and cause problems. (Sometimes things just works but it is 50-50 change.)" And we are seeing this mixing currently in Pangeo environments built with repo2docker (https://github.com/pangeo-data/pangeo-cloud-federation/pull/305).

Described in detail https://github.com/jupyter/repo2docker/pull/714#issuecomment-505278413

Because we aren't changing versions here I suspect there aren't going to be issues, but let me know if I can add tests or other modifications.
