### PR TITLE
[MRG] Remove print statement and unused import

### DIFF
--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -4,7 +4,7 @@ import shutil
 
 from os import makedirs
 from os import path
-from urllib.request import build_opener, urlopen, Request
+from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 from zipfile import ZipFile, is_zipfile
 

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -422,14 +422,12 @@ doi_regexp = re.compile(
 def is_doi(val):
     """Returns None if val doesn't match pattern of a DOI.
     http://en.wikipedia.org/wiki/Digital_object_identifier."""
-    print(type(val))
-    print(val)
     return doi_regexp.match(val)
 
 
 def normalize_doi(val):
     """Return just the DOI (e.g. 10.1234/jshd123)
-    from a val that could include a url or doi 
+    from a val that could include a url or doi
     (e.g. https://doi.org/10.1234/jshd123)"""
     m = doi_regexp.match(val)
     return m.group(2)


### PR DESCRIPTION
Remove a stray print statement and an unused import in the zenodo content provider.