### PR TITLE
bump xeus-cling in tests

### DIFF
--- a/tests/external/reproductions.repos.yaml
+++ b/tests/external/reproductions.repos.yaml
@@ -28,7 +28,7 @@
 # get blocked by pinning
 - name: Xeus-Cling
   url: https://github.com/QuantStack/xeus-cling
-  ref: 0.4.5
+  ref: 0.6.0
   verify: jupyter kernelspec list
 # Zenodo record of https://github.com/binder-examples/requirements
 - name: 10.5281/zenodo.3242074


### PR DESCRIPTION
so we don't have an old env relying on the free channel


re-do of #722, gets tests passing in #719