### PR TITLE
[MRG] Adding bash to Dockerfile to fix git-credential-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN mkdir /tmp/wheelhouse \
 
 FROM alpine:${ALPINE_VERSION}
 
-# install python, git
-RUN apk add --no-cache git git-lfs python3
+# install python, git, bash
+RUN apk add --no-cache git git-lfs python3 bash
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,8 @@ Bug fixes
 ---------
 - Prevent building the image as root if --user-id and --user-name are not specified
   in :pr:`676` by :user:`Xarthisius`.
+- Add bash to Dockerfile to fix usage of private repos with git-crendential-env in
+  :pr:`738` by :user:`eexwhyzee`
 
 
 Version 0.9.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,7 +23,7 @@ Bug fixes
 - Prevent building the image as root if --user-id and --user-name are not specified
   in :pr:`676` by :user:`Xarthisius`.
 - Add bash to Dockerfile to fix usage of private repos with git-crendential-env in
-  :pr:`738` by :user:`eexwhyzee`
+  :pr:`738` by :user:`eexwhyzee`.
 
 
 Version 0.9.0


### PR DESCRIPTION
Re: #736 

Since `alpine` images  don't include bash by default, this breaks the usage private repos with `git-credential-env` which requires [bash](https://github.com/jupyter/repo2docker/blob/master/docker/git-credential-env#L1).....small PR to just add bash to the `Dockerfile` (image size increased ~5MB)