### PR TITLE
refreeze 2019-07-16

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,92 +1,93 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-05-29 19:01:18 UTC
+# Frozen on 2019-07-16 13:18:20 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - _libgcc_mutex=0.1=main
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
-  - bzip2=1.0.6=h14c3975_1002
-  - ca-certificates=2019.3.9=hecc5488_0
-  - certifi=2019.3.9=py37_0
+  - bzip2=1.0.8=h516909a_0
+  - ca-certificates=2019.6.16=hecc5488_0
+  - certifi=2019.6.16=py37_1
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py37_1000
-  - ipykernel=5.1.1=py37h24bf2e0_0
-  - ipython=7.5.0=py37h24bf2e0_0
+  - ipykernel=5.1.1=py37h5ca1d4c_0
+  - ipython=7.6.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.13.3=py37_0
+  - jedi=0.14.1=py37_0
   - jinja2=2.10.1=py_0
   - jsonschema=3.0.1=py37_0
-  - jupyter_client=5.2.4=py_3
+  - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libsodium=1.0.16=h14c3975_1001
-  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libsodium=1.0.17=h516909a_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
   - notebook=5.7.8=py37_1
-  - openssl=1.1.1b=h14c3975_1
-  - pandoc=2.7.2=0
+  - openssl=1.1.1c=h516909a_0
+  - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.4.0=py_0
+  - parso=0.5.1=py_0
   - pexpect=4.7.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.1=py37_0
-  - prometheus_client=0.6.0=py_0
+  - pip=19.1.1=py37_0
+  - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.2=py37h516909a_0
-  - python=3.7.3=h5b0a415_0
+  - pyrsistent=0.15.3=py37h516909a_0
+  - python=3.7.3=h33d41f4_1
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.1=py37hc4ba49a_1
-  - readline=7.0=hf8c457e_1001
+  - pyzmq=18.0.2=py37hc4ba49a_1
+  - readline=8.0=hf8c457e_0
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py37_0
   - six=1.12.0=py37_1000
-  - sqlite=3.28.0=h8b20d00_0
+  - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1001
-  - tornado=6.0.2=py37h516909a_0
+  - tk=8.6.9=hed695b0_1002
+  - tornado=6.0.3=py37h516909a_0
   - traitlets=4.3.2=py37_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py37_0
   - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h14c3975_1001
-  - zeromq=4.3.1=hf484d3e_1000
-  - zlib=1.2.11=h14c3975_1004
+  - zeromq=4.3.2=he1b5a44_2
+  - zlib=1.2.11=h516909a_1005
   - pip:
-    - alembic==1.0.10
+    - alembic==1.0.11
     - asn1crypto==0.24.0
     - async-generator==1.10
     - certipy==0.1.3
     - cffi==1.12.3
     - chardet==3.0.4
-    - cryptography==2.6.1
+    - cryptography==2.7
     - idna==2.8
     - jupyterhub==1.0.0
-    - mako==1.0.10
+    - mako==1.0.13
     - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.1
+    - oauthlib==3.0.2
     - pamela==1.0.0
     - pycparser==2.19
     - pyopenssl==19.0.0
     - python-editor==1.0.4
     - requests==2.22.0
-    - sqlalchemy==1.3.4
+    - sqlalchemy==1.3.5
     - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,53 +1,54 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-05-29 18:56:16 UTC
+# Frozen on 2019-07-16 13:14:12 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - _libgcc_mutex=0.1=main
   - backports=1.0=py_2
   - backports.shutil_get_terminal_size=1.0.0=py_3
   - backports_abc=0.5=py_1
-  - ca-certificates=2019.3.9=hecc5488_0
-  - certifi=2019.3.9=py27_0
+  - ca-certificates=2019.6.16=hecc5488_0
+  - certifi=2019.6.16=py27_1
   - decorator=4.4.0=py_0
   - enum34=1.1.6=py27_1001
   - futures=3.2.0=py27_1000
   - ipykernel=4.8.2=py27_0
   - ipython=5.8.0=py27_0
   - ipython_genutils=0.2.0=py_1
-  - jupyter_client=5.2.4=py_3
+  - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libsodium=1.0.16=h14c3975_1001
-  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libsodium=1.0.17=h516909a_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
   - ncurses=6.1=hf484d3e_1002
-  - openssl=1.1.1b=h14c3975_1
-  - pathlib2=2.3.3=py27_1000
+  - openssl=1.1.1c=h516909a_0
+  - pathlib2=2.3.4=py27_0
   - pexpect=4.7.0=py27_0
   - pickleshare=0.7.5=py27_1000
-  - pip=19.1=py27_0
+  - pip=19.1.1=py27_0
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py_1001
   - pygments=2.4.2=py_0
-  - python=2.7.15=h721da81_1008
+  - python=2.7.15=h5a48372_1009
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.1=py27hc4ba49a_1
-  - readline=7.0=hf8c457e_1001
+  - pyzmq=18.0.2=py27hc4ba49a_1
+  - readline=8.0=hf8c457e_0
   - scandir=1.10.0=py27h14c3975_0
   - setuptools=41.0.1=py27_0
   - simplegeneric=0.8.1=py_1
   - singledispatch=3.4.0.3=py27_1000
   - six=1.12.0=py27_1000
-  - sqlite=3.28.0=h8b20d00_0
-  - tk=8.6.9=h84994c4_1001
+  - sqlite=3.29.0=hcee41ef_0
+  - tk=8.6.9=hed695b0_1002
   - tornado=5.1.1=py27h14c3975_1000
   - traitlets=4.3.2=py27_1000
   - wcwidth=0.1.7=py_1
   - wheel=0.33.4=py27_0
-  - zeromq=4.3.1=hf484d3e_1000
-  - zlib=1.2.11=h14c3975_1004
+  - zeromq=4.3.2=he1b5a44_2
+  - zlib=1.2.11=h516909a_1005
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,91 +1,92 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-05-29 18:58:24 UTC
+# Frozen on 2019-07-16 13:15:56 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - _libgcc_mutex=0.1=main
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
-  - ca-certificates=2019.3.9=hecc5488_0
-  - certifi=2019.3.9=py36_0
+  - ca-certificates=2019.6.16=hecc5488_0
+  - certifi=2019.6.16=py36_1
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py36_1000
-  - ipykernel=5.1.1=py36h24bf2e0_0
-  - ipython=7.5.0=py36h24bf2e0_0
+  - ipykernel=5.1.1=py36h5ca1d4c_0
+  - ipython=7.6.1=py36h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.13.3=py36_0
+  - jedi=0.14.1=py36_0
   - jinja2=2.10.1=py_0
   - jsonschema=3.0.1=py36_0
-  - jupyter_client=5.2.4=py_3
+  - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.35.4=py36_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libsodium=1.0.16=h14c3975_1001
-  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libsodium=1.0.17=h516909a_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
   - markupsafe=1.1.1=py36h14c3975_0
   - mistune=0.8.4=py36h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
   - notebook=5.7.8=py36_1
-  - openssl=1.1.1b=h14c3975_1
-  - pandoc=2.7.2=0
+  - openssl=1.1.1c=h516909a_0
+  - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.4.0=py_0
+  - parso=0.5.1=py_0
   - pexpect=4.7.0=py36_0
   - pickleshare=0.7.5=py36_1000
-  - pip=19.1=py36_0
-  - prometheus_client=0.6.0=py_0
+  - pip=19.1.1=py36_0
+  - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.2=py36h516909a_0
-  - python=3.6.7=h381d211_1004
+  - pyrsistent=0.15.3=py36h516909a_0
+  - python=3.6.7=h357f687_1005
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.1=py36hc4ba49a_1
-  - readline=7.0=hf8c457e_1001
+  - pyzmq=18.0.2=py36hc4ba49a_1
+  - readline=8.0=hf8c457e_0
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py36_0
   - six=1.12.0=py36_1000
-  - sqlite=3.28.0=h8b20d00_0
+  - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py36_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1001
-  - tornado=6.0.2=py36h516909a_0
+  - tk=8.6.9=hed695b0_1002
+  - tornado=6.0.3=py36h516909a_0
   - traitlets=4.3.2=py36_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py36_0
   - widgetsnbextension=3.4.2=py36_1000
   - xz=5.2.4=h14c3975_1001
-  - zeromq=4.3.1=hf484d3e_1000
-  - zlib=1.2.11=h14c3975_1004
+  - zeromq=4.3.2=he1b5a44_2
+  - zlib=1.2.11=h516909a_1005
   - pip:
-    - alembic==1.0.10
+    - alembic==1.0.11
     - asn1crypto==0.24.0
     - async-generator==1.10
     - certipy==0.1.3
     - cffi==1.12.3
     - chardet==3.0.4
-    - cryptography==2.6.1
+    - cryptography==2.7
     - idna==2.8
     - jupyterhub==1.0.0
-    - mako==1.0.10
+    - mako==1.0.13
     - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.1
+    - oauthlib==3.0.2
     - pamela==1.0.0
     - pycparser==2.19
     - pyopenssl==19.0.0
     - python-editor==1.0.4
     - requests==2.22.0
-    - sqlalchemy==1.3.4
+    - sqlalchemy==1.3.5
     - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-05-29 18:58:24 UTC
+# Generated on 2019-07-16 13:15:56 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.4.2

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,92 +1,93 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-05-29 19:01:18 UTC
+# Frozen on 2019-07-16 13:18:20 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
+  - _libgcc_mutex=0.1=main
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
-  - bzip2=1.0.6=h14c3975_1002
-  - ca-certificates=2019.3.9=hecc5488_0
-  - certifi=2019.3.9=py37_0
+  - bzip2=1.0.8=h516909a_0
+  - ca-certificates=2019.6.16=hecc5488_0
+  - certifi=2019.6.16=py37_1
   - decorator=4.4.0=py_0
   - defusedxml=0.5.0=py_1
   - entrypoints=0.3=py37_1000
-  - ipykernel=5.1.1=py37h24bf2e0_0
-  - ipython=7.5.0=py37h24bf2e0_0
+  - ipykernel=5.1.1=py37h5ca1d4c_0
+  - ipython=7.6.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.13.3=py37_0
+  - jedi=0.14.1=py37_0
   - jinja2=2.10.1=py_0
   - jsonschema=3.0.1=py37_0
-  - jupyter_client=5.2.4=py_3
+  - jupyter_client=5.3.1=py_0
   - jupyter_core=4.4.0=py_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libsodium=1.0.16=h14c3975_1001
-  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
+  - libsodium=1.0.17=h516909a_0
+  - libstdcxx-ng=9.1.0=hdf63c60_0
   - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_2
   - nbformat=4.4.0=py_1
   - ncurses=6.1=hf484d3e_1002
   - notebook=5.7.8=py37_1
-  - openssl=1.1.1b=h14c3975_1
-  - pandoc=2.7.2=0
+  - openssl=1.1.1c=h516909a_0
+  - pandoc=2.7.3=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.4.0=py_0
+  - parso=0.5.1=py_0
   - pexpect=4.7.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.1=py37_0
-  - prometheus_client=0.6.0=py_0
+  - pip=19.1.1=py37_0
+  - prometheus_client=0.7.1=py_0
   - prompt_toolkit=2.0.9=py_0
   - ptyprocess=0.6.0=py_1001
   - pygments=2.4.2=py_0
-  - pyrsistent=0.15.2=py37h516909a_0
-  - python=3.7.3=h5b0a415_0
+  - pyrsistent=0.15.3=py37h516909a_0
+  - python=3.7.3=h33d41f4_1
   - python-dateutil=2.8.0=py_0
-  - pyzmq=18.0.1=py37hc4ba49a_1
-  - readline=7.0=hf8c457e_1001
+  - pyzmq=18.0.2=py37hc4ba49a_1
+  - readline=8.0=hf8c457e_0
   - send2trash=1.5.0=py_0
   - setuptools=41.0.1=py37_0
   - six=1.12.0=py37_1000
-  - sqlite=3.28.0=h8b20d00_0
+  - sqlite=3.29.0=hcee41ef_0
   - terminado=0.8.2=py37_0
   - testpath=0.4.2=py_1001
-  - tk=8.6.9=h84994c4_1001
-  - tornado=6.0.2=py37h516909a_0
+  - tk=8.6.9=hed695b0_1002
+  - tornado=6.0.3=py37h516909a_0
   - traitlets=4.3.2=py37_1000
   - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
   - wheel=0.33.4=py37_0
   - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h14c3975_1001
-  - zeromq=4.3.1=hf484d3e_1000
-  - zlib=1.2.11=h14c3975_1004
+  - zeromq=4.3.2=he1b5a44_2
+  - zlib=1.2.11=h516909a_1005
   - pip:
-    - alembic==1.0.10
+    - alembic==1.0.11
     - asn1crypto==0.24.0
     - async-generator==1.10
     - certipy==0.1.3
     - cffi==1.12.3
     - chardet==3.0.4
-    - cryptography==2.6.1
+    - cryptography==2.7
     - idna==2.8
     - jupyterhub==1.0.0
-    - mako==1.0.10
+    - mako==1.0.13
     - nteract-on-jupyter==2.0.12
-    - oauthlib==3.0.1
+    - oauthlib==3.0.2
     - pamela==1.0.0
     - pycparser==2.19
     - pyopenssl==19.0.0
     - python-editor==1.0.4
     - requests==2.22.0
-    - sqlalchemy==1.3.4
+    - sqlalchemy==1.3.5
     - urllib3==1.25.3
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-05-29 19:01:18 UTC
+# Generated on 2019-07-16 13:18:20 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.4.2


### PR DESCRIPTION
includes fixed certifi package which solves the specific case in #725

a few package bumps, too, including ipython, jupyter_client, tornado, and zeromq

Closes #725