### PR TITLE
[MRG] Call parent preassemble scripts methods

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -292,7 +292,7 @@ class RBuildPack(PythonBuildPack):
         return super().get_build_scripts() + scripts
 
     def get_preassemble_script_files(self):
-        files = {}
+        files = super().get_preassemble_script_files()
         installR_path = self.binder_path("install.R")
         if os.path.exists(installR_path):
             files[installR_path] = installR_path

--- a/tests/unit/test_preassemble.py
+++ b/tests/unit/test_preassemble.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+from repo2docker import buildpacks
+
+
+@pytest.mark.parametrize("binder_dir", ["", ".binder", "binder"])
+def test_combine_preassemble_steps(tmpdir, binder_dir):
+    tmpdir.chdir()
+    if binder_dir:
+        os.mkdir(binder_dir)
+
+    # create two empty files for the build pack to use for pre-assembly
+    open(os.path.join(binder_dir, "requirements.txt"), "w").close()
+    open(os.path.join(binder_dir, "install.R"), "w").close()
+
+    # trigger R build pack detection
+    with open(os.path.join(binder_dir, "runtime.txt"), "w") as f:
+        f.write("r-2019-01-30")
+
+    bp = buildpacks.RBuildPack()
+    files = bp.get_preassemble_script_files()
+
+    assert len(files) == 2
+    assert os.path.join(binder_dir, "requirements.txt") in files
+    assert os.path.join(binder_dir, "install.R") in files


### PR DESCRIPTION
Without this we don't collect the files that other build packs need to
copy them over to the container in the pre-assemble stage.

Needs a test to stop it from coming back.

closes #751 