### PR TITLE
Add support for Julia 1.2.0

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -22,6 +22,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         "1.0.4",
         "1.1.0",
         "1.1.1",
+        "1.2.0",
     ]
 
     @property


### PR DESCRIPTION
Julia 1.2.0 is released :)

I believe the julia_version-default test should now automatically test on 1.2.0 with this PR.