### PR TITLE
[WIP] Upgrade IRKernel version to 1.0.2

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -174,7 +174,7 @@ class RBuildPack(PythonBuildPack):
         devtools_version = "2018-02-01"
 
         # IRKernel version - specified as a tag in the IRKernel repository
-        irkernel_version = "0.8.11"
+        irkernel_version = "1.0.2"
 
         mran_url = "https://mran.microsoft.com/snapshot/{}".format(
             self.checkpoint_date.isoformat()


### PR DESCRIPTION
This PR upgrades IPKernel version to 1.0.2 and closes https://github.com/jupyter/repo2docker/issues/765, hopefully without breaking anything else :eyes:   
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
