### PR TITLE
Handle different file encodings

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -6,7 +6,7 @@ from collections import Mapping
 from ruamel.yaml import YAML
 
 from ..base import BaseImage
-from ...utils import is_local_pip_requirement, open_utf8convert_read
+from ...utils import is_local_pip_requirement
 
 # pattern for parsing conda dependency line
 PYTHON_REGEX = re.compile(r"python\s*=+\s*([\d\.]*)")
@@ -140,7 +140,7 @@ class CondaBuildPack(BaseImage):
             self._environment_yaml = {}
             return self._environment_yaml
 
-        with open_utf8convert_read(environment_yml) as f:
+        with open(environment_yml) as f:
             env = YAML().load(f)
             # check if the env file is empty, if so instantiate an empty dictionary.
             if env is None:

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -6,7 +6,7 @@ from collections import Mapping
 from ruamel.yaml import YAML
 
 from ..base import BaseImage
-from ...utils import is_local_pip_requirement
+from ...utils import is_local_pip_requirement, open_utf8convert_read
 
 # pattern for parsing conda dependency line
 PYTHON_REGEX = re.compile(r"python\s*=+\s*([\d\.]*)")
@@ -140,7 +140,7 @@ class CondaBuildPack(BaseImage):
             self._environment_yaml = {}
             return self._environment_yaml
 
-        with open(environment_yml) as f:
+        with open_utf8convert_read(environment_yml) as f:
             env = YAML().load(f)
             # check if the env file is empty, if so instantiate an empty dictionary.
             if env is None:

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -2,7 +2,7 @@
 import os
 
 from ..conda import CondaBuildPack
-from ...utils import is_local_pip_requirement, open_utf8convert_read
+from ...utils import is_local_pip_requirement, open_guess_encoding
 
 
 class PythonBuildPack(CondaBuildPack):
@@ -86,7 +86,7 @@ class PythonBuildPack(CondaBuildPack):
             requirements_txt = self.binder_path(name)
             if not os.path.exists(requirements_txt):
                 continue
-            with open_utf8convert_read(requirements_txt) as f:
+            with open_guess_encoding(requirements_txt) as f:
                 for line in f:
                     if is_local_pip_requirement(line):
                         return False

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -2,7 +2,7 @@
 import os
 
 from ..conda import CondaBuildPack
-from ...utils import is_local_pip_requirement
+from ...utils import is_local_pip_requirement, open_utf8convert_read
 
 
 class PythonBuildPack(CondaBuildPack):
@@ -86,7 +86,7 @@ class PythonBuildPack(CondaBuildPack):
             requirements_txt = self.binder_path(name)
             if not os.path.exists(requirements_txt):
                 continue
-            with open(requirements_txt) as f:
+            with open_utf8convert_read(requirements_txt) as f:
                 for line in f:
                     if is_local_pip_requirement(line):
                         return False

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -3,6 +3,7 @@ from functools import partial
 import os
 import re
 import subprocess
+import chardet
 
 from shutil import copystat, copy2
 
@@ -68,6 +69,22 @@ def chdir(path):
         yield
     finally:
         os.chdir(old_dir)
+
+@contextmanager
+def open_utf8convert_read(path):
+    with open(path, "rb") as f:
+        file_to_encode = f.read()
+
+    encoding_detection_result = chardet.detect(file_to_encode)
+    if not "utf-8" in encoding_detection_result:
+        with open(path, "wb") as f:
+            f.write(file_to_encode.decode(encoding_detection_result["encoding"]).encode("utf-8"))
+
+    file = open(path)
+    try:
+        yield file
+    finally:
+        file.close()
 
 
 def validate_and_generate_port_mapping(port_mappings):

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -81,7 +81,6 @@ def open_guess_encoding(path):
     with open(path, "rb") as f:
         for line in f.readlines():
             detector.feed(line)
-            print(str(i) + str(detector.done))
             if detector.done:
                 break
     detector.close()

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -70,17 +70,23 @@ def chdir(path):
     finally:
         os.chdir(old_dir)
 
+
 @contextmanager
-def open_utf8convert_read(path):
+def open_guess_encoding(path):
+    """
+    Open a file in text mode, specifying its encoding,
+    that we guess using chardet.
+    """
+    detector = chardet.universaldetector.UniversalDetector()
     with open(path, "rb") as f:
-        file_to_encode = f.read()
+        for line in f.readlines():
+            detector.feed(line)
+            print(str(i) + str(detector.done))
+            if detector.done:
+                break
+    detector.close()
 
-    encoding_detection_result = chardet.detect(file_to_encode)
-    if not "utf-8" in encoding_detection_result:
-        with open(path, "wb") as f:
-            f.write(file_to_encode.decode(encoding_detection_result["encoding"]).encode("utf-8"))
-
-    file = open(path)
+    file = open(path, encoding=detector.result["encoding"])
     try:
         yield file
     finally:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -115,11 +115,12 @@ def test_normalize_doi():
 
 def test_open_guess_encoding():
     data = "Rică nu știa să zică râu, rățușcă, rămurică."
-    with tempfile.NamedTemporaryFile(mode='wb') as test_file:
+    with tempfile.NamedTemporaryFile(mode="wb") as test_file:
         test_file.write(str.encode(data, "utf-16"))
         test_file.seek(0)
         with utils.open_guess_encoding(test_file.name) as fd:
             assert fd.read() == data
+
 
 @pytest.mark.parametrize(
     "req, is_local",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ import os
 from repo2docker import utils
 import pytest
 import subprocess
+import tempfile
 
 
 def test_capture_cmd_no_capture_success():
@@ -111,6 +112,14 @@ def test_normalize_doi():
     assert utils.normalize_doi("https://doi.org/10.1234/jshd123") == "10.1234/jshd123"
     assert utils.normalize_doi("http://dx.doi.org/10.1234/jshd123") == "10.1234/jshd123"
 
+
+def test_open_guess_encoding():
+    data = "Rică nu știa să zică râu, rățușcă, rămurică."
+    with tempfile.NamedTemporaryFile(mode='wb') as test_file:
+        test_file.write(str.encode(data, "utf-16"))
+        test_file.seek(0)
+        with utils.open_guess_encoding(test_file.name) as fd:
+            assert fd.read() == data
 
 @pytest.mark.parametrize(
     "req, is_local",


### PR DESCRIPTION
This should fix https://github.com/jupyter/repo2docker/issues/764

Decided to use *chardet* to guess the encoding because I liked the idea of reusing the function for ``environment.yml`` also (not sure if this was the right call).

* [x] implement function to detect encoding
* [x] add tests

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
