### PR TITLE
include repo2docker version in docker tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ RUN apk add --no-cache git python3 python3-dev
 
 # build wheels in first image
 ADD . /tmp/src
+RUN cd /tmp/src && git clean -xfd && git status
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
- && pip3 wheel --no-cache-dir /tmp/src
+ && pip3 wheel --no-cache-dir /tmp/src \
+ && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}
 
@@ -17,7 +19,8 @@ RUN apk add --no-cache git git-lfs python3 bash
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse
-RUN pip3 install --no-cache-dir /tmp/wheelhouse/*.whl
+RUN pip3 install --no-cache-dir /tmp/wheelhouse/*.whl \
+ && pip3 list
 
 # add git-credential helper
 COPY ./docker/git-credential-env /usr/local/bin/git-credential-env

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# when building jupyter/repo2docker:master also push jupyter/repo2docker:abcd1234
-
-HASH_IMAGE="$DOCKER_REPO:${SOURCE_COMMIT:0:8}"
-docker tag $DOCKER_REPO:$DOCKER_TAG $HASH_IMAGE
-docker push $HASH_IMAGE
+# when building jupyter/repo2docker:master
+# also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
+version=$(docker run $DOCKER_REPO:$DOCKER_TAG jupyter-repo2docker --version | sed s@+@-@)
+VERSION_IMAGE="$DOCKER_REPO:$version"
+docker tag $DOCKER_REPO:$DOCKER_TAG "$VERSION_IMAGE"
+docker push "$VERSION_IMAGE"


### PR DESCRIPTION
so instead of `abc123` it's `0.10.0-4.abc123`

- 0.10.0 is the latest tag
- 4 is the number of commits since then
- abc123 is the hash

also should fix the presence of `dirty` in the version in our images by calling `git clean`