### PR TITLE
Add script to compare Dockerfiles generated by current and older…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ test_file_text.txt
 
 
 \.vscode/
+
+tests/dockerfile_diff.sh

--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -196,3 +196,16 @@ Server:
 ```
 
 Then you are good to go!
+
+## Building the documentation locally
+
+If you only changed the documentation, you can also build the documentation locally using `sphinx` .
+
+```bash
+#pip install -r docs/doc-requirements.txt
+
+cd docs/
+make html
+```
+
+Then open the file `docs/build/html/index.html` in your browser.

--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -202,7 +202,7 @@ Then you are good to go!
 If you only changed the documentation, you can also build the documentation locally using `sphinx` .
 
 ```bash
-#pip install -r docs/doc-requirements.txt
+pip install -r docs/doc-requirements.txt
 
 cd docs/
 make html


### PR DESCRIPTION
Here is how the script output looks like comparing the version in this PR with `0.10.0`:

<details>
<summary>Click to expand</summary>

```
~/git/elife-sprint/repo2docker/tests$ R2D_COMPARE_TO=0.10.0 CMD=$(pwd)/dockerfile_diff.sh find . -name 'verify' -execdir bash -c '$CMD $(pwd)' \;
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/dockerfile/binder-dir (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/dockerfile/legacy (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/dockerfile/jupyter-stack (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/dockerfile/simple (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/base/node10 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/simple-py2 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/environment.py-2.7.frozen.yml /tmp/kernel-environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d2-2e7-2efrozen-2eyml-2567aa /tmp/kernel-environment.yml
73c73
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/binder-dir (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.5.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e5-2efrozen-2eyml-0ffe38 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/default-env (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/simple (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/requirements (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/py37 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/conda/repo-path (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/r/simple (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
79c79
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
81c81
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
83c83
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
118c118
< R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='0.8.11')" && \
---
> R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='1.0.2')" && \
181c181
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/r/description-file (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
79c79
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
81c81
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
83c83
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
118c118
< R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='0.8.11')" && \
---
> R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='1.0.2')" && \
174c174
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/stencila-py/py (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
136c136
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/stencila-py/pyjp (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/binder-folder-lock (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
137c137
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/environment-yml (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
133c133
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/pipfile-lock (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
137c137
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/requirements-txt (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/setup-py-explicit (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/py36 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.6.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e6-2efrozen-2eyml-051b93 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
137c137
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/py2-with-server-and-kernel-req (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/environment.py-2.7.frozen.yml /tmp/kernel-environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d2-2e7-2efrozen-2eyml-2567aa /tmp/kernel-environment.yml
73c73
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
142c142
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/setup-py-implicit (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/setup-py-explicit-in-binder-dir (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/pipfile/binder-folder (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julia_version-1.0.2 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
72c72
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
74c74
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
76c76
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
139c139
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/pyplot-requirements (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
74c74
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
76c76
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
78c78
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
80c80
< COPY julia/install-repo-dependencies.jl /tmp/install-repo-dependencies.jl
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fjulia-2finstall-2drepo-2ddependencies-2ejl-5d8153 /tmp/install-repo-dependencies.jl
152c152
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julialegacy_version-0.6.3 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
74c74
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
76c76
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
78c78
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
80c80
< COPY julia/install-repo-dependencies.jl /tmp/install-repo-dependencies.jl
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fjulia-2finstall-2drepo-2ddependencies-2ejl-5d8153 /tmp/install-repo-dependencies.jl
145c145
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julia_version-default (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
65c65
< ENV JULIA_VERSION 1.1.1
---
> ENV JULIA_VERSION 1.2.0
72c72
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
74c74
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
76c76
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
139c139
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julialegacy_version-1.1 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
74c74
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
76c76
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
78c78
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
80c80
< COPY julia/install-repo-dependencies.jl /tmp/install-repo-dependencies.jl
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fjulia-2finstall-2drepo-2ddependencies-2ejl-5d8153 /tmp/install-repo-dependencies.jl
145c145
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julialegacy_version-1.0 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
74c74
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
76c76
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
78c78
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
80c80
< COPY julia/install-repo-dependencies.jl /tmp/install-repo-dependencies.jl
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fjulia-2finstall-2drepo-2ddependencies-2ejl-5d8153 /tmp/install-repo-dependencies.jl
145c145
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/julia/julialegacy_version-1 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
74c74
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
76c76
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
78c78
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
80c80
< COPY julia/install-repo-dependencies.jl /tmp/install-repo-dependencies.jl
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fjulia-2finstall-2drepo-2ddependencies-2ejl-5d8153 /tmp/install-repo-dependencies.jl
145c145
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/nix/binder-dir (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
64c64
< COPY nix/install-nix.bash /home/${NB_USER}/.local/bin/install-nix.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2finstall-2dnix-2ebash-1e21a3 /home/${NB_USER}/.local/bin/install-nix.bash
66c66
< COPY nix/nix-shell-wrapper /usr/local/bin/nix-shell-wrapper
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2fnix-2dshell-2dwrapper-ffe677 /usr/local/bin/nix-shell-wrapper
125c125
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/nix/ignore-outside (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
64c64
< COPY nix/install-nix.bash /home/${NB_USER}/.local/bin/install-nix.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2finstall-2dnix-2ebash-1e21a3 /home/${NB_USER}/.local/bin/install-nix.bash
66c66
< COPY nix/nix-shell-wrapper /usr/local/bin/nix-shell-wrapper
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2fnix-2dshell-2dwrapper-ffe677 /usr/local/bin/nix-shell-wrapper
125c125
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/nix/simple (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
64c64
< COPY nix/install-nix.bash /home/${NB_USER}/.local/bin/install-nix.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2finstall-2dnix-2ebash-1e21a3 /home/${NB_USER}/.local/bin/install-nix.bash
66c66
< COPY nix/nix-shell-wrapper /usr/local/bin/nix-shell-wrapper
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2fnix-2dshell-2dwrapper-ffe677 /usr/local/bin/nix-shell-wrapper
125c125
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/nix/start (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
64c64
< COPY nix/install-nix.bash /home/${NB_USER}/.local/bin/install-nix.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2finstall-2dnix-2ebash-1e21a3 /home/${NB_USER}/.local/bin/install-nix.bash
66c66
< COPY nix/nix-shell-wrapper /usr/local/bin/nix-shell-wrapper
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fnix-2fnix-2dshell-2dwrapper-ffe677 /usr/local/bin/nix-shell-wrapper
125c125
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/stencila-r (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
79c79
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
81c81
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
83c83
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
118c118
< R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='0.8.11')" && \
---
> R --quiet -e "devtools::install_github('IRkernel/IRkernel', ref='1.0.2')" && \
187c187
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/apt-packages (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
131c131
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/py2-with-kernel-requirements (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/environment.py-2.7.frozen.yml /tmp/kernel-environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d2-2e7-2efrozen-2eyml-2567aa /tmp/kernel-environment.yml
73c73
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
135c135
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/binder-dir (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
136c136
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/numpy (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
130c130
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/postBuild (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
130c130
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/py2 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml-ff93f5 /tmp/environment.yml
71c71
< COPY conda/environment.py-2.7.frozen.yml /tmp/kernel-environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d2-2e7-2efrozen-2eyml-2567aa /tmp/kernel-environment.yml
73c73
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
132c132
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/default (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/py35 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.5.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e5-2efrozen-2eyml-0ffe38 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/usr-bin (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/py3 (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/start/postBuild (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
130c130
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
Comparing /home/daniel/git/elife-sprint/repo2docker/tests/venv/start/start-script (local 0.10.0-28.gddf94bc.dirty vs. 0.10.0)
67c67
< COPY conda/activate-conda.sh /etc/profile.d/activate-conda.sh
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh-c5c51c /etc/profile.d/activate-conda.sh
69c69
< COPY conda/environment.py-3.7.frozen.yml /tmp/environment.yml
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2fenvironment-2epy-2d3-2e7-2efrozen-2eyml-df7f55 /tmp/environment.yml
71c71
< COPY conda/install-miniconda.bash /tmp/install-miniconda.bash
---
> COPY build_script_files/-2fhome-2fdaniel-2fgit-2felife-2dsprint-2frepo2docker-2frepo2docker-2fbuildpacks-2fconda-2finstall-2dminiconda-2ebash-215e5e /tmp/install-miniconda.bash
123c123
< LABEL repo2docker.version="0.10.0+0.g69c09ae.dirty"
---
> LABEL repo2docker.version="0.10.0+28.gddf94bc.dirty"
```

</details>


Might the changes in the `COPY` statement actually be an error?