### PR TITLE
[MRG] Restore the hooks directory when building the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk add --no-cache git python3 python3-dev
 
 # build wheels in first image
 ADD . /tmp/src
-RUN cd /tmp/src && git clean -xfd && git status
+# restore the hooks directory so that the repository isn't marked as dirty
+RUN cd /tmp/src && git clean -xfd && git checkout -- hooks && git status
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \


### PR DESCRIPTION
This is an attempt to fix [the fact that the repo is still marked as dirty](https://github.com/jupyterhub/mybinder.org-deploy/pull/1151#issuecomment-529171875) because now the files are missing.

* [ ] check the docker cloud logs https://cloud.docker.com/u/jupyter/repository/docker/jupyter/repo2docker/timeline