### PR TITLE
Add baseline infra for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,20 @@
+# https://docs.microsoft.com/azure/devops/pipelines/ecosystems/python
+pool:
+  vmImage: "ubuntu-16.04"
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.6'
+
+- script: python -m pip install --upgrade pip setuptools wheel
+  displayName: 'Install tools'
+
+- script: pip install -r dev-requirements.txt
+  displayName: 'Install dev requirements'
+
+- script: pip install -e .
+  displayName: 'Install r2d'
+
+- script: pytest --durations 10 --cov repo2docker -v tests
+  displayName: 'Run pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,5 +16,6 @@ steps:
 - script: pip install -e .
   displayName: 'Install r2d'
 
-- script: pytest --durations 10 --cov repo2docker -v tests
+# venv conda 
+- script: pytest --durations 10 --cov repo2docker -vs tests/unit
   displayName: 'Run pytest'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytest>=3.6
 wheel
 pytest-cov
 pre-commit
+requests


### PR DESCRIPTION
Partially addresses #744 

- Enable Azure Pipelines
- Add minimal tests
- Azure Pipelines needed requests so adding to dev requirements