### PR TITLE
use getpass.getuser instead of os.getlogin

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,11 @@ steps:
   inputs:
     versionSpec: '3.6'
 
+- script: |
+   git config --global user.email "ci@fake.tld"
+   git config --global user.name "CI Services"
+  displayName: 'Set up git'
+
 - script: python -m pip install --upgrade pip setuptools wheel
   displayName: 'Install tools'
 

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import tempfile
 import time
+from getpass import getuser
 
 
 def test_env():
@@ -13,7 +14,7 @@ def test_env():
     """
     ts = str(time.time())
     with tempfile.TemporaryDirectory() as tmpdir:
-        username = os.getlogin()
+        username = getuser()
         subprocess.check_call(
             [
                 "repo2docker",

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -7,6 +7,7 @@ import time
 import os
 import tempfile
 import random
+from getpass import getuser
 
 import docker
 import pytest
@@ -46,7 +47,7 @@ def read_port_mapping_response(
     request.addfinalizer(td.cleanup)
     tmpdir.chdir()
 
-    username = os.getlogin()
+    username = getuser()
     tmpdir.mkdir("username")
     r2d = Repo2Docker(
         repo=str(tmpdir.mkdir("repo")),

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import tempfile
 import time
+from getpass import getuser
 from unittest import mock
 
 from repo2docker import Repo2Docker
@@ -26,7 +27,7 @@ def test_user():
     """
     ts = str(time.time())
     # FIXME: Use arbitrary login here, We need it now since we wanna put things to volume.
-    username = os.getlogin()
+    username = getuser()
     userid = str(os.geteuid())
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = os.path.realpath(tmpdir)

--- a/tests/unit/test_volumes.py
+++ b/tests/unit/test_volumes.py
@@ -1,10 +1,12 @@
 """
 Test that volume mounts work when running
 """
+
 import os
 import subprocess
 import tempfile
 import time
+from getpass import getuser
 
 
 def test_volume_abspath():
@@ -15,7 +17,7 @@ def test_volume_abspath():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = os.path.realpath(tmpdir)
 
-        username = os.getlogin()
+        username = getuser()
         subprocess.check_call(
             [
                 "repo2docker",
@@ -54,7 +56,7 @@ def test_volume_relpath():
                     "--user-id",
                     str(os.geteuid()),
                     "--user-name",
-                    os.getlogin(),
+                    getuser(),
                     tmpdir,
                     "--",
                     "/bin/bash",


### PR DESCRIPTION
os.getlogin apparently doesn't work everywhere (can raise OSError, inappropriate ioctl for device)

and is failing on azure pipelines tests