### PR TITLE
[MRG] Bumped conda version to 4.7.12

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -4,7 +4,7 @@ set -ex
 
 cd $(dirname $0)
 MINICONDA_VERSION=4.7.10
-CONDA_VERSION=4.7.10
+CONDA_VERSION=4.7.12
 # Only MD5 checksums are available for miniconda
 # Can be obtained from https://repo.continuum.io/miniconda/
 MD5SUM="1c945f2b3335c7b2b15130b1b2dc5cf4"

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,6 +5,6 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["conda", "--version"]).decode("utf8").strip()
-assert out == "conda 4.7.10", out
+assert out == "conda 4.7.12", out
 
 import numpy


### PR DESCRIPTION
This PR bumps the Conda version from 4.7.10 installed by most recent Miniconda release to 4.7.12 which is the most recent version of Conda itself.

4.7.12 release of Conda fixed a number of issues related to permissions that I was experiencing when using Conda + Docker on other projects.