### PR TITLE
[MRG] Upadte RStudio 1.1 - > 1.2, minor update to RShiny

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -201,13 +201,12 @@ class RBuildPack(PythonBuildPack):
         We set the snapshot date used to install R libraries from based on the
         contents of runtime.txt.
         """
-        # Latest version as of October 2, 2019
-        rstudio_url = "https://download2.rstudio.org/rstudio-server-1.2.5001-amd64.deb"
+        # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
+        rstudio_url = "https://download2.rstudio.org/server/trusty/amd64/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
         rstudio_checksum = "d77039693dd09c3ca48038aa74cd921a"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
-        # Latest version as of October 2, 2019
         shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"
         shiny_checksum = "9aeef6613e7f58f21c97a4600921340e"
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -202,7 +202,7 @@ class RBuildPack(PythonBuildPack):
         contents of runtime.txt.
         """
         # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
-        rstudio_url = "https://download2.rstudio.org/server/trusty/amd64/rstudio-server-1.2.5001-amd64.deb"
+        rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
         rstudio_checksum = "d77039693dd09c3ca48038aa74cd921a"
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -248,13 +248,14 @@ class RBuildPack(PythonBuildPack):
                     "root",
                     r"""
                     apt-get update && \
-                    apt-get install --yes r-base={} && \
-                    apt-get install --yes r-base-dev={} && \
+                    apt-get install --yes r-base={R_version} \
+                         r-base-dev={R_version} \
+                         libclang-dev && \
                     apt-get -qq purge && \
                     apt-get -qq clean && \
                     rm -rf /var/lib/apt/lists/*
                     """.format(
-                        self.r_version
+                        R_version=self.r_version
                     ),
                 ),
             ]

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -40,6 +40,8 @@ class RBuildPack(PythonBuildPack):
 
     The `r-base` package from Ubuntu apt repositories is used to install
     R itself, rather than any of the methods from https://cran.r-project.org/.
+
+    The `r-base-dev` package is installed as advised in RStudio instructions.
     """
 
     @property
@@ -177,7 +179,7 @@ class RBuildPack(PythonBuildPack):
         # For R 3.4 we use the default Ubuntu package, for other versions we
         # install from a different PPA
         if V(self.r_version) < V("3.5"):
-            packages.append("r-base")
+            packages.append("r-base", "r-base-dev")
 
         return super().get_packages().union(packages)
 
@@ -245,6 +247,7 @@ class RBuildPack(PythonBuildPack):
                     r"""
                     apt-get update && \
                     apt-get install --yes r-base={} && \
+                    apt-get install --yes r-base-dev={} && \
                     apt-get -qq purge && \
                     apt-get -qq clean && \
                     rm -rf /var/lib/apt/lists/*

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -205,7 +205,7 @@ class RBuildPack(PythonBuildPack):
         We set the snapshot date used to install R libraries from based on the
         contents of runtime.txt.
         """
-        
+
         # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
         rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -207,8 +207,8 @@ class RBuildPack(PythonBuildPack):
         rstudio_checksum = "d33881b9ab786c09556c410e7dc477de"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
-        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"
-        shiny_checksum = "9aeef6613e7f58f21c97a4600921340e"
+        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.7.907-amd64.deb"
+        shiny_checksum = "78371a8361ba0e7fec44edd2b8e425ac"
 
         # Version of MRAN to pull devtools from.
         devtools_version = "2018-02-01"

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -181,6 +181,7 @@ class RBuildPack(PythonBuildPack):
         if V(self.r_version) < V("3.5"):
             packages.append("r-base")
             packages.append("r-base-dev")
+            packages.append("libclang-dev")
 
         return super().get_packages().union(packages)
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -204,7 +204,7 @@ class RBuildPack(PythonBuildPack):
         # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
         rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
-        rstudio_checksum = "d77039693dd09c3ca48038aa74cd921a"
+        rstudio_checksum = "d33881b9ab786c09556c410e7dc477de"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
         shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -201,13 +201,15 @@ class RBuildPack(PythonBuildPack):
         We set the snapshot date used to install R libraries from based on the
         contents of runtime.txt.
         """
-        rstudio_url = "https://download2.rstudio.org/rstudio-server-1.1.419-amd64.deb"
+        # Latest version as of October 2, 2019
+        rstudio_url = "https://download2.rstudio.org/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
-        rstudio_checksum = "24cd11f0405d8372b4168fc9956e0386"
+        rstudio_checksum = "d77039693dd09c3ca48038aa74cd921a"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
-        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.7.907-amd64.deb"
-        shiny_checksum = "78371a8361ba0e7fec44edd2b8e425ac"
+        # Latest version as of October 2, 2019
+        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"
+        shiny_checksum = "9aeef6613e7f58f21c97a4600921340e"
 
         # Version of MRAN to pull devtools from.
         devtools_version = "2018-02-01"

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -179,7 +179,8 @@ class RBuildPack(PythonBuildPack):
         # For R 3.4 we use the default Ubuntu package, for other versions we
         # install from a different PPA
         if V(self.r_version) < V("3.5"):
-            packages.append("r-base", "r-base-dev")
+            packages.append("r-base")
+            packages.append("r-base-dev")
 
         return super().get_packages().union(packages)
 
@@ -205,9 +206,9 @@ class RBuildPack(PythonBuildPack):
         """
         
         # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
-        rstudio_url = "https://download2.rstudio.org/rstudio-server-1.1.419-amd64.deb"
+        rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5001-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
-        rstudio_checksum = "24cd11f0405d8372b4168fc9956e0386"
+        rstudio_checksum = "d33881b9ab786c09556c410e7dc477de"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
         shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -201,14 +201,15 @@ class RBuildPack(PythonBuildPack):
         We set the snapshot date used to install R libraries from based on the
         contents of runtime.txt.
         """
+        
         # Via https://rstudio.com/products/rstudio/download-server/debian-ubuntu/
-        rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5001-amd64.deb"
+        rstudio_url = "https://download2.rstudio.org/rstudio-server-1.1.419-amd64.deb"
         # This is MD5, because that is what RStudio download page provides!
-        rstudio_checksum = "d33881b9ab786c09556c410e7dc477de"
+        rstudio_checksum = "24cd11f0405d8372b4168fc9956e0386"
 
         # Via https://www.rstudio.com/products/shiny/download-server/
-        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.7.907-amd64.deb"
-        shiny_checksum = "78371a8361ba0e7fec44edd2b8e425ac"
+        shiny_url = "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb"
+        shiny_checksum = "9aeef6613e7f58f21c97a4600921340e"
 
         # Version of MRAN to pull devtools from.
         devtools_version = "2018-02-01"


### PR DESCRIPTION
Based on [this Discourse discussion with Tim](https://discourse.jupyter.org/t/widget-failing-in-shiny-app), regarding an error I have on a widget in a Shiny app, I made two small edits in r.py:

1. Updated the version of RStudio Server to the latest, stable release available on the official RStudio website (URL commented in code). This involved two code lines, namely, the URL and the MD5.

2. Updated the version of Shiny Server, too, as it could also be relevant to the present error. This involved the same types of edits as above.

Thank you!

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
