### PR TITLE
adduser: useradd --no-log-init to reduce lastlog size

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -42,10 +42,17 @@ ARG NB_UID
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER}
+RUN groupadd \
+        --gid ${NB_UID} \
+        ${NB_USER} &&
+    useradd \
+        --comment "Default user" \
+        --create-home \
+        --gid ${NB_UID} \
+        --no-log-init \
+        --shell /bin/bash \
+        --uid ${NB_UID} \
+        ${NB_USER}
 
 RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
     DISTRO="bionic" && \

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -44,7 +44,7 @@ ENV HOME /home/${NB_USER}
 
 RUN groupadd \
         --gid ${NB_UID} \
-        ${NB_USER} &&
+        ${NB_USER} && \
     useradd \
         --comment "Default user" \
         --create-home \


### PR DESCRIPTION
If the Docker host does not support sparse files `/var/log/lastlog` can be extremely large if a large UID is set. `--no-log-init` prevents lastlog being created, but this requires `useradd` instead of `adduser`

closes #223 