### PR TITLE
WIP: Podman backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
 - docker
 python:
 - 3.6
+before_install:
+# https://github.com/adelton/freeipa-container/blob/podman/.travis.yml
+- sudo sh -c "add-apt-repository -y ppa:projectatomic/ppa && apt-get update -y && apt-get install -y podman"
 install:
 # Make a wheel and install it to test to catch possible
 # issues with releases
@@ -65,6 +68,20 @@ env:
   - REPO_TYPE=nix
   - REPO_TYPE=dockerfile
   - REPO_TYPE=external
+
+  - REPO_TYPE=lint ENGINE=podman
+  - REPO_TYPE=unit ENGINE=podman
+  - REPO_TYPE=base ENGINE=podman
+  - REPO_TYPE=conda ENGINE=podman
+  - REPO_TYPE=pipfile ENGINE=podman
+  - REPO_TYPE=venv ENGINE=podman
+  - REPO_TYPE=stencila-r ENGINE=podman
+  - REPO_TYPE=stencila-py ENGINE=podman
+  - REPO_TYPE=julia ENGINE=podman
+  - REPO_TYPE=r ENGINE=podman
+  - REPO_TYPE=nix ENGINE=podman
+  - REPO_TYPE=dockerfile ENGINE=podman
+  - REPO_TYPE=external ENGINE=podman
   global:
   - secure: gX7IOkbjlvcDwIH24sOLhutINx6TZRwujEusMWh1dqgYG2D69qQai/mTrRXO9PGRrsvQwIBk4RcILKAiZnk5O2Z1hLoIHk/oU2mNUmE44dDm4Xf/VTTdeYhjeOTR9B+KJ9NVwPxuSEDSND3lD7yFfvCqNXykipEhBtTliLupjWVxxXnaz0aZTYHUPJwanxdUc06AphSPwZjtm1m3qMUU8v7UdTGGAdW3NlgkKw0Xx2x5W31fW676vskC/GNQAbcRociYipuhSFWV4lu+6d8XF2xVO97xtzf54tBQzt6RgVfAKtiqkEIYSzJQBBpkQ6SM6yg+fQoQpOo8jPU9ZBjvaoopUG9vn8HRS/OtQrDcG3kEFnFAnaes8Iqtidp1deTn27LIlfCTl7kTFOp8yaaNlIMHJTJKTEMRhfdDlBYx7qiH8e9d/z37lupzY2loLHeNHdMRS1uYsfacZsmrnu9vAdpQmP1LuHivBPZEvgerinADaJiekelWOIEn956pDrno/YgnzP0i9LEBYnbbunqT8oEzLintNt5CXGdhkiG60j38McKCIn4sD6jbMMwgsqVFdClCBersyorKhOs7P8at5vX4xf8fMiKPC8LZPzYVIQYzCjmwSOFQ+Rzmz5gSj+DRTANKfHpzZCKZEF6amBYMGE1O5osF8m6M10vtW9ToK+s=
   - secure: Cfhb0BUT54JjEZD8n44Jj+o1lt5p32Lfg7W/euTyZ61YylDx0+XEYTzfWcwxOzH9fLpWr6dDrBMGHA/FPqsWA5BkoGdiBJ1OOVy2tmDRButctobWM3SVwa+Rhh8bZWlK8yKT2S3n6CtK4mesmjzdbUShL7YnKOSl8LBaTT5Y5oT8Oxsq51pfg8fJUImim8H20t8H7emaEzZorF4OSGRtajcAgukt5YoAqTEVDq+bFRBHZalxkcRqLhsGe3CCWa28kjGTL4MPZpCI6/AXIXHzihfG3rGq40ZT8jZ9GPP3MBgkiJWtFiTC9h16G34b/JI/TD40zCmoW9/9oVjRK4UlLGCAv6bgzFhCRof2abhB9NTZDniNzkO0T15uHs3VLbLCPYB0xYyClAFxm2P6e8WPChyENKfTNh+803IKFFo4JaTjOnKzi89N72v5+bT6ghP932nmjJr1AO65xjw63CeDmaLoHDY73n11DibybWQgEeiNzJuSzbIHyqMPhW5XqeroEjKKstdPHtVfOViI9ywjEMy0HCPsspaVI7Aow0Iv8E4Ajvd32W7z0h0fSCx/i25hEOAo2vhBsmQKJA7IquB3N88M11L874h/8J+oc/osW1EB5z7Ukke5YCq94Qh3qImSIhJULXMMc1QjEqYsqhLXtiMG2HUge0Y5hwwnnbEIRMQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ services:
 python:
 - 3.6
 before_install:
+# Install podman
 - sudo sh -c "add-apt-repository -y ppa:projectatomic/ppa && apt-get update -y && apt-get install -y podman slirp4netns"
 - sudo sh -c "echo \"[registries.search]\nregistries = ['docker.io']\n\" > /etc/containers/registries.conf"
+# On ubuntu:xenial running podman as non-root defaults to using VFS instead of overlay as the kernel is too old to support fuse-overlayfs
+# VFS is extremely inefficient so for now run podman as root
+- /bin/echo -e '#!/bin/sh\nexec sudo podman "$@"' > ~/bin/podman && chmod +x ~/bin/podman
 - podman info
 install:
 # Make a wheel and install it to test to catch possible

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ services:
 python:
 - 3.6
 before_install:
-# https://github.com/adelton/freeipa-container/blob/podman/.travis.yml
-- sudo sh -c "add-apt-repository -y ppa:projectatomic/ppa && apt-get update -y && apt-get install -y podman"
+- sudo sh -c "add-apt-repository -y ppa:projectatomic/ppa && apt-get update -y && apt-get install -y podman slirp4netns"
+- sudo sh -c "echo \"[registries.search]\nregistries = ['docker.io']\n\" > /etc/containers/registries.conf"
+- podman info
 install:
 # Make a wheel and install it to test to catch possible
 # issues with releases
@@ -57,6 +58,7 @@ env:
   matrix:
   - REPO_TYPE=lint
   - REPO_TYPE=unit
+
   - REPO_TYPE=base
   - REPO_TYPE=conda
   - REPO_TYPE=pipfile
@@ -69,8 +71,6 @@ env:
   - REPO_TYPE=dockerfile
   - REPO_TYPE=external
 
-  - REPO_TYPE=lint ENGINE=podman
-  - REPO_TYPE=unit ENGINE=podman
   - REPO_TYPE=base ENGINE=podman
   - REPO_TYPE=conda ENGINE=podman
   - REPO_TYPE=pipfile ENGINE=podman
@@ -82,6 +82,7 @@ env:
   - REPO_TYPE=nix ENGINE=podman
   - REPO_TYPE=dockerfile ENGINE=podman
   - REPO_TYPE=external ENGINE=podman
+
   global:
   - secure: gX7IOkbjlvcDwIH24sOLhutINx6TZRwujEusMWh1dqgYG2D69qQai/mTrRXO9PGRrsvQwIBk4RcILKAiZnk5O2Z1hLoIHk/oU2mNUmE44dDm4Xf/VTTdeYhjeOTR9B+KJ9NVwPxuSEDSND3lD7yFfvCqNXykipEhBtTliLupjWVxxXnaz0aZTYHUPJwanxdUc06AphSPwZjtm1m3qMUU8v7UdTGGAdW3NlgkKw0Xx2x5W31fW676vskC/GNQAbcRociYipuhSFWV4lu+6d8XF2xVO97xtzf54tBQzt6RgVfAKtiqkEIYSzJQBBpkQ6SM6yg+fQoQpOo8jPU9ZBjvaoopUG9vn8HRS/OtQrDcG3kEFnFAnaes8Iqtidp1deTn27LIlfCTl7kTFOp8yaaNlIMHJTJKTEMRhfdDlBYx7qiH8e9d/z37lupzY2loLHeNHdMRS1uYsfacZsmrnu9vAdpQmP1LuHivBPZEvgerinADaJiekelWOIEn956pDrno/YgnzP0i9LEBYnbbunqT8oEzLintNt5CXGdhkiG60j38McKCIn4sD6jbMMwgsqVFdClCBersyorKhOs7P8at5vX4xf8fMiKPC8LZPzYVIQYzCjmwSOFQ+Rzmz5gSj+DRTANKfHpzZCKZEF6amBYMGE1O5osF8m6M10vtW9ToK+s=
   - secure: Cfhb0BUT54JjEZD8n44Jj+o1lt5p32Lfg7W/euTyZ61YylDx0+XEYTzfWcwxOzH9fLpWr6dDrBMGHA/FPqsWA5BkoGdiBJ1OOVy2tmDRButctobWM3SVwa+Rhh8bZWlK8yKT2S3n6CtK4mesmjzdbUShL7YnKOSl8LBaTT5Y5oT8Oxsq51pfg8fJUImim8H20t8H7emaEzZorF4OSGRtajcAgukt5YoAqTEVDq+bFRBHZalxkcRqLhsGe3CCWa28kjGTL4MPZpCI6/AXIXHzihfG3rGq40ZT8jZ9GPP3MBgkiJWtFiTC9h16G34b/JI/TD40zCmoW9/9oVjRK4UlLGCAv6bgzFhCRof2abhB9NTZDniNzkO0T15uHs3VLbLCPYB0xYyClAFxm2P6e8WPChyENKfTNh+803IKFFo4JaTjOnKzi89N72v5+bT6ghP932nmjJr1AO65xjw63CeDmaLoHDY73n11DibybWQgEeiNzJuSzbIHyqMPhW5XqeroEjKKstdPHtVfOViI9ywjEMy0HCPsspaVI7Aow0Iv8E4Ajvd32W7z0h0fSCx/i25hEOAo2vhBsmQKJA7IquB3N88M11L874h/8J+oc/osW1EB5z7Ukke5YCq94Qh3qImSIhJULXMMc1QjEqYsqhLXtiMG2HUge0Y5hwwnnbEIRMQ=

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -193,10 +193,11 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        "--podman",
-        dest="podman",
-        action="store_true",
-        help="Use Podman instead of Docker client.",
+        "--engine",
+        default="docker",
+        type=str,
+        choices=("docker", "podman"),
+        help="Container engine.",
     )
 
     return argparser
@@ -345,8 +346,7 @@ def make_r2d(argv=None):
     if args.target_repo_dir:
         r2d.target_repo_dir = args.target_repo_dir
 
-    if args.podman:
-        r2d.podman = True
+    r2d.engine = args.engine
 
     return r2d
 

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -192,6 +192,13 @@ def get_argparser():
         "--cache-from", action="append", default=[], help=Repo2Docker.cache_from.help
     )
 
+    argparser.add_argument(
+        "--podman",
+        dest="podman",
+        action="store_true",
+        help="Use Podman instead of Docker client.",
+    )
+
     return argparser
 
 
@@ -337,6 +344,9 @@ def make_r2d(argv=None):
 
     if args.target_repo_dir:
         r2d.target_repo_dir = args.target_repo_dir
+
+    if args.podman:
+        r2d.podman = True
 
     return r2d
 

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -466,8 +466,9 @@ class Repo2Docker(Application):
     def push_image(self):
         """Push docker image to registry"""
         if self.engine == "podman":
-            raise NotImplementedError("podman push not implemented")
-        client = docker.APIClient(version="auto", **kwargs_from_env())
+            client = PodmanClient()
+        else:
+            client = docker.APIClient(version="auto", **kwargs_from_env())
         # Build a progress setup for each layer, and only emit per-layer
         # info every 1.5s
         progress_layers = {}

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -39,6 +39,7 @@ from .buildpacks import (
     RBuildPack,
 )
 from . import contentproviders
+from .podman import PodmanClient
 from .utils import ByteSpecification, chdir
 
 
@@ -634,6 +635,14 @@ class Repo2Docker(Application):
             except DockerException as e:
                 self.log.error(
                     "\nDocker client initialization error: %s.\nCheck if docker is running on the host.\n",
+                    e,
+                )
+                self.exit(1)
+            try:
+                docker_client = PodmanClient()
+            except Exception as e:
+                self.log.error(
+                    "\nPodman error: %s.\nCheck if podman is installed.\n",
                     e,
                 )
                 self.exit(1)

--- a/repo2docker/podman.py
+++ b/repo2docker/podman.py
@@ -1,4 +1,5 @@
 # Use Podman isntead of Docker
+import json
 from tempfile import TemporaryDirectory
 import tarfile
 from .utils import execute_cmd
@@ -6,7 +7,7 @@ from .utils import execute_cmd
 class PodmanClient:
 
     def __init__(self):
-        list(execute_cmd(['podman', 'info']))
+        execute_cmd(['podman', 'info'])
 
     def build(self, **kwargs):
         """
@@ -85,3 +86,11 @@ class PodmanClient:
             print(cmdline)
             for line in execute_cmd(cmdline):
                 yield line
+
+    def images(self):
+        print('podman image list')
+        lines = list(execute_cmd(
+            ['podman', 'image', 'list', '--format', 'json'], capture=True))
+        # print('lines', lines)
+        # print('json', json.loads(''.join(lines)))
+        return json.loads(''.join(lines))

--- a/repo2docker/podman.py
+++ b/repo2docker/podman.py
@@ -1,0 +1,87 @@
+# Use Podman isntead of Docker
+from tempfile import TemporaryDirectory
+import tarfile
+from .utils import execute_cmd
+
+class PodmanClient:
+
+    def __init__(self):
+        list(execute_cmd(['podman', 'info']))
+
+    def build(self, **kwargs):
+        """
+        Implement docker.Client.build in podman
+        https://docker-py.readthedocs.io/en/stable/api.html
+        """
+        print('podman build kwargs: %s', kwargs)
+        cmdargs = []
+
+        bargs = kwargs.pop('buildargs', {})
+        for k, v in bargs.items():
+            cmdargs.extend(['--build-arg', '{}={}'.format(k, v)])
+
+        # podman --cache-from is a NOOP
+        cachef = kwargs.pop('cache_from', [])
+        if cachef:
+            cmdargs.extend(['--cache-from', ','.join(cachef)])
+
+        try:
+            climits = kwargs.pop('container_limits')
+            try:
+                cmdargs.extend(['--cpuset-cpus', climits.pop('cpusetcpus')])
+            except KeyError:
+                pass
+            try:
+                cmdargs.extend(['--cpu-shares', climits.pop('cpushares')])
+            except KeyError:
+                pass
+            try:
+                cmdargs.extend(['--memory', climits.pop('memory')])
+            except KeyError:
+                pass
+            try:
+                cmdargs.extend(['--memory-swap', climits.pop('memswap')])
+            except KeyError:
+                pass
+        except KeyError:
+            pass
+
+        try:
+            if kwargs.pop('forcerm'):
+                cmdargs.append('--force-rm')
+        except KeyError:
+            pass
+
+        try:
+            if kwargs.pop('rm'):
+                cmdargs.append('--rm')
+        except KeyError:
+            pass
+
+        try:
+            cmdargs.extend(['--tag', kwargs.pop('tag')])
+        except KeyError:
+            pass
+
+        for ignore in (
+            'custom_context',
+            'decode',
+        ):
+            try:
+                kwargs.pop(ignore)
+            except KeyError:
+                pass
+
+        fileobj = kwargs.pop('fileobj')
+
+        with TemporaryDirectory() as builddir:
+            tarf = tarfile.open(fileobj=fileobj)
+            tarf.extractall(builddir)
+            print(builddir)
+            for line in execute_cmd(['ls', '-lRa', builddir]):
+                print(line)
+
+            cmdline = ['podman', 'build'] + cmdargs + [builddir]
+            print(cmdline)
+            for line in execute_cmd(cmdline):
+                yield line

--- a/repo2docker/podman.py
+++ b/repo2docker/podman.py
@@ -1,96 +1,238 @@
-# Use Podman isntead of Docker
+# Use Podman instead of Docker
 import json
+from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
 import tarfile
 from .utils import execute_cmd
 
+# https://docker-py.readthedocs.io/en/stable/containers.html
+
+
+def exec_podman(args, capture=False, **kwargs):
+    cmd = ["podman"] + args
+    print("Executing: {} {}".format(" ".join(cmd), kwargs))
+    try:
+        p = execute_cmd(cmd, capture=capture, **kwargs)
+    except CalledProcessError:
+        print(kwargs["stdout"])
+        print(kwargs["stderr"])
+        raise
+    if capture:
+        yield from p
+    for line in p:
+        print(line)
+        # pass
+
+
+class Container:
+    def __init__(self, cid):
+        self.id = cid
+        self.reload()
+
+    def reload(self):
+        lines = list(
+            exec_podman(
+                ["inspect", "--type", "container", "--format", "json", self.id],
+                capture=True,
+            )
+        )
+        d = json.loads("".join(lines))
+        assert len(d) == 1
+        self.attrs = d[0]
+        assert self.attrs["Id"] == self.id
+
+    def logs(self, stream=False):
+        if stream:
+
+            def iter_logs(cid):
+                exited = False
+                try:
+                    for line in exec_podman(
+                        ["attach", "--no-stdin", cid], capture=True
+                    ):
+                        if exited or line.startswith(
+                            "Error: you can only attach to running containers"
+                        ):
+                            # Swallow all output to ensure process exited
+                            print(line)
+                            exited = True
+                            continue
+                        else:
+                            yield line.encode("utf-8")
+                except CalledProcessError as e:
+                    print(e, line.encode("utf-8"))
+                    if e.returncode == 125 and exited:
+                        for line in exec_podman(["logs", self.id], capture=True):
+                            yield line.encode("utf-8")
+                    else:
+                        raise
+
+            return iter_logs(self.id)
+        return "".join(exec_podman(["logs", self.id], capture=True))
+
+    def kill(self, signal="KILL"):
+        for line in exec_podman(["kill", "--signal", signal, self.id]):
+            print(line)
+
+    def remove(self, **kwargs):
+        print("podman remove kwargs: {}".format(kwargs))
+        cmdargs = ["rm"]
+        if kwargs.pop("v", False):
+            cmdargs.append("--volumes")
+        if kwargs.pop("link", False):
+            cmdargs.append("--link")
+        if kwargs.pop("force", False):
+            cmdargs.append("--force")
+        for line in exec_podman(cmdargs + [self.id]):
+            print(line)
+
+    @staticmethod
+    def run(image_spec, **kwargs):
+        print("podman run kwargs: {} {}".format(image_spec, kwargs))
+        cmdargs = ["run"]
+
+        try:
+            if kwargs.pop("publish_all_ports"):
+                cmdargs.append("--publish-all")
+        except KeyError:
+            pass
+
+        ports = kwargs.pop("ports", {})
+        for k, v in ports.items():
+            if k.endswith("/tcp"):
+                k = k[:-4]
+            cmdargs.extend(["--publish", "{}:{}".format(k, v)])
+
+        detach = kwargs.pop("detach", False)
+        if detach:
+            cmdargs.append("--detach")
+
+        volumes = kwargs.pop("volumes", {})
+        for k, v in volumes.items():
+            raise NotImplementedError("podman run volumes not implemented")
+
+        env = kwargs.pop("env", [])
+        for e in env:
+            cmdargs.extend(["--env", e])
+
+        if kwargs.pop("remove", False):
+            cmdargs.append("--rm")
+
+        command = kwargs.pop("command", [])
+
+        cmdline = cmdargs + [image_spec] + command
+        lines = list(exec_podman(cmdline, capture=True))
+        if detach:
+            # If image was pulled the progress logs will also be present
+            # assert len(lines) == 1, lines
+            return Container(lines[-1].strip())
+        else:
+            return lines
+
+    def stop(self, timeout=10):
+        for line in exec_podman(["stop", "--timeout", str(timeout), self.id]):
+            print(line)
+
+    @property
+    def status(self):
+        return self.attrs["State"]["Status"]
+
+
 class PodmanClient:
 
+    containers = Container
+
     def __init__(self):
-        execute_cmd(['podman', 'info'])
+        exec_podman(["info"])
 
     def build(self, **kwargs):
         """
         Implement docker.Client.build in podman
         https://docker-py.readthedocs.io/en/stable/api.html
         """
-        print('podman build kwargs: %s', kwargs)
-        cmdargs = []
+        print("podman build kwargs: %s", kwargs)
+        cmdargs = ["build"]
 
-        bargs = kwargs.pop('buildargs', {})
+        bargs = kwargs.pop("buildargs", {})
         for k, v in bargs.items():
-            cmdargs.extend(['--build-arg', '{}={}'.format(k, v)])
+            cmdargs.extend(["--build-arg", "{}={}".format(k, v)])
 
         # podman --cache-from is a NOOP
-        cachef = kwargs.pop('cache_from', [])
+        cachef = kwargs.pop("cache_from", [])
         if cachef:
-            cmdargs.extend(['--cache-from', ','.join(cachef)])
+            cmdargs.extend(["--cache-from", ",".join(cachef)])
 
         try:
-            climits = kwargs.pop('container_limits')
+            climits = kwargs.pop("container_limits")
             try:
-                cmdargs.extend(['--cpuset-cpus', climits.pop('cpusetcpus')])
+                cmdargs.extend(["--cpuset-cpus", climits.pop("cpusetcpus")])
             except KeyError:
                 pass
             try:
-                cmdargs.extend(['--cpu-shares', climits.pop('cpushares')])
+                cmdargs.extend(["--cpu-shares", climits.pop("cpushares")])
             except KeyError:
                 pass
             try:
-                cmdargs.extend(['--memory', climits.pop('memory')])
+                cmdargs.extend(["--memory", climits.pop("memory")])
             except KeyError:
                 pass
             try:
-                cmdargs.extend(['--memory-swap', climits.pop('memswap')])
+                cmdargs.extend(["--memory-swap", climits.pop("memswap")])
             except KeyError:
                 pass
         except KeyError:
             pass
 
         try:
-            if kwargs.pop('forcerm'):
-                cmdargs.append('--force-rm')
+            if kwargs.pop("forcerm"):
+                cmdargs.append("--force-rm")
         except KeyError:
             pass
 
         try:
-            if kwargs.pop('rm'):
-                cmdargs.append('--rm')
+            if kwargs.pop("rm"):
+                cmdargs.append("--rm")
         except KeyError:
             pass
 
         try:
-            cmdargs.extend(['--tag', kwargs.pop('tag')])
+            cmdargs.extend(["--tag", kwargs.pop("tag")])
         except KeyError:
             pass
 
-        for ignore in (
-            'custom_context',
-            'decode',
-        ):
+        try:
+            cmdargs.extend(["--file", kwargs.pop("dockerfile")])
+        except KeyError:
+            pass
+
+        for ignore in ("custom_context", "decode"):
             try:
                 kwargs.pop(ignore)
             except KeyError:
                 pass
 
-        fileobj = kwargs.pop('fileobj')
+        # Avoid try-except so that if build errors occur they don't result in a
+        # confusing message about an exception whilst handling an exception
+        if "fileobj" in kwargs:
+            fileobj = kwargs.pop("fileobj")
 
-        with TemporaryDirectory() as builddir:
-            tarf = tarfile.open(fileobj=fileobj)
-            tarf.extractall(builddir)
-            print(builddir)
-            for line in execute_cmd(['ls', '-lRa', builddir]):
-                print(line)
-
-            cmdline = ['podman', 'build'] + cmdargs + [builddir]
-            print(cmdline)
-            for line in execute_cmd(cmdline):
-                yield line
+            with TemporaryDirectory() as builddir:
+                tarf = tarfile.open(fileobj=fileobj)
+                tarf.extractall(builddir)
+                print(builddir)
+                for line in execute_cmd(["ls", "-lRa", builddir]):
+                    print(line)
+                for line in exec_podman(cmdargs + [builddir], capture=True):
+                    yield {"stream": line}
+        else:
+            builddir = kwargs.pop("path")
+            for line in exec_podman(cmdargs + [builddir], capture=True):
+                yield {"stream": line}
 
     def images(self):
-        print('podman image list')
-        lines = list(execute_cmd(
-            ['podman', 'image', 'list', '--format', 'json'], capture=True))
-        # print('lines', lines)
-        # print('json', json.loads(''.join(lines)))
-        return json.loads(''.join(lines))
+        lines = "".join(
+            exec_podman(["image", "list", "--format", "json"], capture=True)
+        )
+        if lines.strip():
+            return json.loads(lines)
+        return []

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -50,6 +50,8 @@ def execute_cmd(cmd, capture=False, **kwargs):
             if c == b"\n":
                 yield flush()
             c_last = c
+        if buf:
+            yield flush()
     finally:
         ret = proc.wait()
         if ret != 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ def pytest_collect_file(parent, path):
         return RemoteRepoList(path, parent)
 
 
+def engine_args():
+    if os.getenv('ENGINE') == 'podman':
+        return ['--podman']
+    return []
+
+
 def make_test_func(args):
     """Generate a test function that runs repo2docker"""
 
@@ -202,6 +208,7 @@ class LocalRepo(pytest.File):
             args += extra_args
 
         args.append(self.fspath.dirname)
+        args.extend(engine_args())
 
         yield Repo2DockerTest("build", self, args=args)
         yield Repo2DockerTest(self.fspath.basename, self, args=args + ["./verify"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,9 @@ def pytest_collect_file(parent, path):
 
 
 def engine_args():
-    if os.getenv('ENGINE') == 'podman':
-        return ['--podman']
+    engine = os.getenv("ENGINE")
+    if engine:
+        return ["--engine", engine]
     return []
 
 
@@ -199,6 +200,7 @@ class Repo2DockerTest(pytest.Function):
 class LocalRepo(pytest.File):
     def collect(self):
         args = ["--appendix", 'RUN echo "appendix" > /tmp/appendix']
+        args.extend(engine_args())
         # If there's an extra-args.yaml file in a test dir, assume it contains
         # a yaml list with extra arguments to be passed to repo2docker
         extra_args_path = os.path.join(self.fspath.dirname, "extra-args.yaml")
@@ -208,7 +210,6 @@ class LocalRepo(pytest.File):
             args += extra_args
 
         args.append(self.fspath.dirname)
-        args.extend(engine_args())
 
         yield Repo2DockerTest("build", self, args=args)
         yield Repo2DockerTest(self.fspath.basename, self, args=args + ["./verify"])

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -1,0 +1,64 @@
+"""Tests for podman client"""
+
+import pytest
+import os
+import re
+from repo2docker.podman import Container, PodmanClient
+from subprocess import CalledProcessError
+from time import sleep
+
+
+def test_run_attach():
+    client = PodmanClient()
+    out = client.containers.run("busybox", command=["id", "-un"], remove=True)
+    # If image was pulled the progress logs will also be present
+    # assert len(out) == 1
+    assert out[-1].strip() == "root", out
+
+
+def test_run_detach_nostream():
+    client = PodmanClient()
+    c = client.containers.run("busybox", command=["id", "-un"], detach=True)
+    assert isinstance(c, Container)
+    assert re.match("^[0-9a-f]{64}$", c.id)
+    sleep(1)
+    c.reload()
+    assert c.status == "exited"
+    out = c.logs()
+    assert out.strip() == "root"
+    c.remove()
+    with pytest.raises(CalledProcessError):
+        c.reload()
+
+
+# @pytest.mark.parametrize('sleep', [0, 5])
+def test_run_detach_stream_live():
+    client = PodmanClient()
+    c = client.containers.run(
+        "busybox", command=["sh", "-c", "sleep 5; id -un"], detach=True
+    )
+    assert isinstance(c, Container)
+    assert re.match("^[0-9a-f]{64}$", c.id)
+    sleep(1)
+    c.reload()
+    assert c.status == "running"
+    out = "\n".join(line.decode("utf-8") for line in c.logs(stream=True))
+    assert out.strip() == "root"
+    c.remove()
+    with pytest.raises(CalledProcessError):
+        c.reload()
+
+
+def test_run_detach_stream_exited():
+    client = PodmanClient()
+    c = client.containers.run("busybox", command=["id", "-un"], detach=True)
+    assert isinstance(c, Container)
+    assert re.match("^[0-9a-f]{64}$", c.id)
+    sleep(1)
+    c.reload()
+    assert c.status == "exited"
+    out = "\n".join(line.decode("utf-8") for line in c.logs(stream=True))
+    assert out.strip() == "root"
+    c.remove()
+    with pytest.raises(CalledProcessError):
+        c.reload()


### PR DESCRIPTION
I had a go at implementing a Podman backend (Docker has mysteriously broken itself on my Fedora install)

Main issues:
- There may be some bugs with hard-links (affects conda, needs to be fixed in the upstream podman project, but coming up with a minimal example for a bug report is tricky)
- Travis VM is too old to run podman in user-mode (requires the fuse-overlayfs driver). The options are to use VFS (works but extremely inefficient) or run as root. On a modern OS such as Fedora 30 running Podman as a normal user with `fuse-overlayfs` should work.
- The [Podman Python client library](https://github.com/containers/python-podman) uses the [varlink interface](https://podman.io/blogs/2019/01/16/podman-varlink.html) which adds unnecessary complication since one of the aims of Podman is to run with minimal privileges and no daemon so I've written a wrapper library that executes `podman`
- `cache_from` isn't implemented by podman

Todo:
- [ ] Implement `push_image`
- [ ] Implement volumes for `podman run`
- [ ] Get rid of print/debug statements
- [ ] Failing test: `REPO_TYPE=stencila-py ENGINE=podman`
- [ ] Check whether `Repo2Docker.find_image` works
- [ ] Refactor behind an Engine class

Closes https://github.com/jupyter/repo2docker/issues/682