### PR TITLE
[WIP] r build-pack: when using ppa install r-recommended

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -250,6 +250,7 @@ class RBuildPack(PythonBuildPack):
                     apt-get update && \
                     apt-get install --yes r-base={R_version} \
                          r-base-dev={R_version} \
+                         r-recommended={R_version} \
                          libclang-dev && \
                     apt-get -qq purge && \
                     apt-get -qq clean && \


### PR DESCRIPTION
https://github.com/jupyterhub/mybinder.org-deploy/issues/1308 is reproducible when running manually:
- `docker run -it --rm ubuntu:18.04`, install base dependencies `apt-get install -y gnupg ca-certificates`
- Setup PPA https://github.com/jupyter/repo2docker/blob/f79bf04a410b1482eb8e7d0e8369e2ba6c5467f4/repo2docker/buildpacks/r.py#L236 https://github.com/jupyter/repo2docker/blob/f79bf04a410b1482eb8e7d0e8369e2ba6c5467f4/repo2docker/buildpacks/r.py#L244
- Install `3.6.1-3bionic` https://github.com/jupyter/repo2docker/blob/f79bf04a410b1482eb8e7d0e8369e2ba6c5467f4/repo2docker/buildpacks/r.py#L78
```
root@abc76a08c669:/# apt-get install r-base=3.6.1-3bionic r-base-dev=3.6.1-3bionic libclang-dev
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 r-base : Depends: r-recommended (= 3.6.1-3bionic) but 3.6.2-1bionic is to be installed
          Recommends: r-base-html but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```
Specifying a version for `r-recommended=3.6.1-3bionic` seems to fix it. Perhaps it's a packaging bug in the upstream 3.6.2 release?

I haven't tested other R versions, I won't have time to follow up on it over the next few day but feel free to take it over or push directly to this branch.