### PR TITLE
Merge pull request #834 from GeorgianaElena/new_badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/jupyter/repo2docker.svg?branch=master)](https://travis-ci.org/jupyter/repo2docker)
 [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](http://repo2docker.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://dev.azure.com/jupyter/repo2docker/_apis/build/status/jupyter.repo2docker?branchName=master)](https://dev.azure.com/jupyter/repo2docker/_build/latest?definitionId=1&branchName=master)
+[![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html)
 
 `repo2docker` fetches a git repository and builds a container image based on
 the configuration files found in the repository.


### PR DESCRIPTION
This makes the contributing guide one-click away from possible contributors :rocket:

However, I'm not sure if the badge should link [CONTRIBUTING.md](https://github.com/jupyter/repo2docker/blob/master/CONTRIBUTING.md) or [the docs](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html). Which one is best? This PR links the badge to the docs.

(P.S. The badge has already been added to TLJH, check it out: [![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html))

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
