### PR TITLE
try to exit on test failure on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ steps:
 - script: pip install -e .
   displayName: 'Install repo2docker'
 
-- script: pushd tests; pytest --durations 10 --cov repo2docker -v $(REPO_TYPE); popd
+- script: pytest --durations 10 --cov repo2docker -v tests/$(REPO_TYPE)
   displayName: 'Run tests $(REPO_TYPE)'
 
 - script: |


### PR DESCRIPTION
failing tests are being reported as success on azure, I assume because the last command (popd) is not exiting with a nonzero status code.


<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->