### PR TITLE
[MRG] update base environment

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,102 +1,114 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-09-13 19:50:21 UTC
+# Frozen on 2020-01-27 12:32:13 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - _libgcc_mutex=0.1=main
-  - alembic=1.1.0=py_0
-  - asn1crypto=0.24.0=py37_1003
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=0_gnu
+  - alembic=1.3.3=py_0
   - async_generator=1.10=py_0
-  - attrs=19.1.0=py_0
+  - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
   - blinker=1.4=py_1
-  - bzip2=1.0.8=h516909a_1
-  - ca-certificates=2019.9.11=hecc5488_0
-  - certifi=2019.9.11=py37_0
+  - ca-certificates=2019.11.28=hecc5488_0
+  - certifi=2019.11.28=py37_0
   - certipy=0.1.3=py_0
-  - cffi=1.12.3=py37h8022711_0
+  - cffi=1.13.2=py37h8022711_0
   - chardet=3.0.4=py37_1003
-  - configurable-http-proxy=4.1.0=node11_1
-  - cryptography=2.7=py37h72c5cf5_0
-  - decorator=4.4.0=py_0
-  - defusedxml=0.5.0=py_1
+  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
+  - cryptography=2.8=py37h72c5cf5_1
+  - decorator=4.4.1=py_0
+  - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
-  - ipykernel=5.1.2=py37h5ca1d4c_0
-  - ipython=7.8.0=py37h5ca1d4c_0
+  - importlib_metadata=1.4.0=py37_0
+  - inflect=4.0.0=py37_1
+  - ipykernel=5.1.3=py37h5ca1d4c_0
+  - ipython=7.11.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.15.1=py37_0
-  - jinja2=2.10.1=py_0
-  - jsonschema=3.0.2=py37_0
-  - jupyter_client=5.3.1=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterhub=1.0.0=py37_0
+  - jaraco.itertools=5.0.0=py_0
+  - jedi=0.16.0=py37_0
+  - jinja2=2.10.3=py_0
+  - jsonschema=3.2.0=py37_0
+  - jupyter_client=5.3.4=py37_1
+  - jupyter_core=4.6.1=py37_0
+  - jupyter_telemetry=0.0.4=py_0
+  - jupyterhub=1.1.0=py37_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
-  - krb5=1.16.3=h05b26f9_1001
+  - krb5=1.16.4=h2fd8d38_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.2.0=h24d8f2e_2
+  - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
-  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py37h14c3975_0
-  - mistune=0.8.4=py37h14c3975_1000
+  - markupsafe=1.1.1=py37h516909a_0
+  - mistune=0.8.4=py37h516909a_1000
+  - more-itertools=8.1.0=py_0
   - nbconvert=5.4.1=py_2
-  - nbformat=4.4.0=py_1
+  - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=11.14.0=he1b5a44_1
+  - nodejs=13.7.0=h10a4023_0
   - notebook=5.7.8=py37_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1c=h516909a_0
+  - openssl=1.1.1d=h516909a_0
   - pamela=1.0.0=py_0
-  - pandoc=2.7.3=0
+  - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.5.1=py_0
-  - pexpect=4.7.0=py37_0
+  - parso=0.6.0=py_0
+  - pexpect=4.8.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.2.3=py37_0
+  - pip=20.0.2=py37_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=2.0.9=py_0
+  - prompt_toolkit=3.0.2=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py37_1
-  - pycurl=7.43.0.2=py37h16ce93b_1
-  - pygments=2.4.2=py_0
+  - pycurl=7.43.0.4=py37h16ce93b_0
+  - pygments=2.5.2=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.0.0=py37_0
-  - pyrsistent=0.15.4=py37h516909a_0
-  - pysocks=1.7.0=py37_0
-  - python=3.7.3=h33d41f4_1
-  - python-dateutil=2.8.0=py_0
+  - pyopenssl=19.1.0=py37_0
+  - pyrsistent=0.15.7=py37h516909a_0
+  - pysocks=1.7.1=py37_0
+  - python=3.7.6=h357f687_2
+  - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
-  - pyzmq=18.1.0=py37h1768529_0
+  - python-json-logger=0.1.11=py_0
+  - pyzmq=18.1.1=py37h1768529_0
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py37_1
+  - ruamel.yaml=0.16.6=py37h516909a_0
+  - ruamel.yaml.clib=0.2.0=py37h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=41.2.0=py37_0
-  - six=1.12.0=py37_1000
-  - sqlalchemy=1.3.8=py37h516909a_0
-  - sqlite=3.29.0=hcee41ef_1
-  - terminado=0.8.2=py37_0
-  - testpath=0.4.2=py_1001
-  - tk=8.6.9=hed695b0_1003
+  - setuptools=45.1.0=py37_0
+  - six=1.14.0=py37_0
+  - sqlalchemy=1.3.13=py37h516909a_0
+  - sqlite=3.30.1=hcee41ef_0
+  - terminado=0.8.3=py37_0
+  - testpath=0.4.4=py_0
+  - tk=8.6.10=hed695b0_0
   - tornado=6.0.3=py37h516909a_0
-  - traitlets=4.3.2=py37_1000
-  - urllib3=1.25.3=py37_0
-  - wcwidth=0.1.7=py_1
+  - traitlets=4.3.3=py37_0
+  - urllib3=1.25.7=py37_0
+  - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
   - wheel=0.33.6=py37_0
   - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -39,6 +39,7 @@ dependencies:
   - jupyter_core=4.6.1=py37_0
   - jupyter_telemetry=0.0.4=py_0
   - jupyterhub-base=1.1.0=py37_2
+  - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0

--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-27 12:32:13 UTC
+# Frozen on 2020-01-29 16:12:17 UTC
 name: r2d
 channels:
   - conda-forge
@@ -19,31 +19,30 @@ dependencies:
   - certipy=0.1.3=py_0
   - cffi=1.13.2=py37h8022711_0
   - chardet=3.0.4=py37_1003
-  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
   - cryptography=2.8=py37h72c5cf5_1
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
-  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
-  - importlib_metadata=1.4.0=py37_0
+  - importlib_metadata=1.5.0=py37_0
   - inflect=4.0.0=py37_1
-  - ipykernel=5.1.3=py37h5ca1d4c_0
+  - ipykernel=5.1.4=py37h5ca1d4c_0
   - ipython=7.11.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.4.2=py_0
+  - ipywidgets=7.5.1=py_0
   - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py37_0
-  - jinja2=2.10.3=py_0
+  - jinja2=2.11.0=py_0
+  - json5=0.8.5=py_0
   - jsonschema=3.2.0=py37_0
   - jupyter_client=5.3.4=py37_1
   - jupyter_core=4.6.1=py37_0
   - jupyter_telemetry=0.0.4=py_0
-  - jupyterhub=1.1.0=py37_0
-  - jupyterlab=0.35.4=py37_0
-  - jupyterlab_server=0.2.0=py_0
+  - jupyterhub-base=1.1.0=py37_2
+  - jupyterlab=1.2.6=py_0
+  - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
-  - ld_impl_linux-64=2.33.1=h53a641e_7
+  - ld_impl_linux-64=2.33.1=h53a641e_8
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
@@ -52,16 +51,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
-  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h516909a_0
   - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.1.0=py_0
-  - nbconvert=5.4.1=py_2
+  - more-itertools=8.2.0=py_0
+  - nbconvert=5.6.1=py37_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=13.7.0=h10a4023_0
-  - notebook=5.7.8=py37_1
+  - notebook=6.0.3=py37_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1d=h516909a_0
@@ -73,7 +70,7 @@ dependencies:
   - pickleshare=0.7.5=py37_1000
   - pip=20.0.2=py37_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.2=py_0
+  - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py37_1
   - pycurl=7.43.0.4=py37h16ce93b_0
@@ -104,8 +101,8 @@ dependencies:
   - urllib3=1.25.7=py37_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.33.6=py37_0
-  - widgetsnbextension=3.4.2=py37_1000
+  - wheel=0.34.1=py37_0
+  - widgetsnbextension=3.5.1=py37_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zipp=2.1.0=py_0

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,52 +1,56 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-09-13 19:45:51 UTC
+# Frozen on 2020-01-27 12:28:36 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - _libgcc_mutex=0.1=main
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=0_gnu
   - backports=1.0=py_2
   - backports.shutil_get_terminal_size=1.0.0=py_3
   - backports_abc=0.5=py_1
-  - ca-certificates=2019.9.11=hecc5488_0
-  - certifi=2019.9.11=py27_0
-  - decorator=4.4.0=py_0
-  - enum34=1.1.6=py27_1001
+  - ca-certificates=2019.11.28=hecc5488_0
+  - certifi=2019.11.28=py27_0
+  - configparser=3.7.3=py27_1
+  - decorator=4.4.1=py_0
+  - entrypoints=0.3=py27_1000
+  - enum34=1.1.6=py27_1002
   - futures=3.3.0=py27_0
   - ipykernel=4.8.2=py27_0
-  - ipython=5.8.0=py27_0
+  - ipython=5.8.0=py27_1
   - ipython_genutils=0.2.0=py_1
-  - jupyter_client=5.3.1=py_0
-  - jupyter_core=4.4.0=py_0
+  - jupyter_client=5.3.4=py27_1
+  - jupyter_core=4.6.1=py27_0
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.2.0=h24d8f2e_2
+  - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.2.0=hdf63c60_2
   - ncurses=6.1=hf484d3e_1002
-  - openssl=1.1.1c=h516909a_0
-  - pathlib2=2.3.4=py27_0
-  - pexpect=4.7.0=py27_0
+  - openssl=1.1.1d=h516909a_0
+  - pathlib2=2.3.5=py27_0
+  - pexpect=4.8.0=py27_0
   - pickleshare=0.7.5=py27_1000
-  - pip=19.2.3=py27_0
+  - pip=20.0.2=py27_0
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py_1001
-  - pygments=2.4.2=py_0
+  - pygments=2.5.2=py_0
   - python=2.7.15=h5a48372_1009
-  - python-dateutil=2.8.0=py_0
-  - pyzmq=18.1.0=py27h1768529_0
+  - python-dateutil=2.8.1=py_0
+  - pyzmq=18.1.1=py27h1768529_0
   - readline=8.0=hf8c457e_0
-  - scandir=1.10.0=py27h14c3975_0
-  - setuptools=41.2.0=py27_0
+  - scandir=1.10.0=py27h516909a_0
+  - setuptools=44.0.0=py27_0
   - simplegeneric=0.8.1=py_1
   - singledispatch=3.4.0.3=py27_1000
-  - six=1.12.0=py27_1000
-  - sqlite=3.29.0=hcee41ef_1
-  - tk=8.6.9=hed695b0_1003
+  - six=1.14.0=py27_0
+  - sqlite=3.30.1=hcee41ef_0
+  - tk=8.6.10=hed695b0_0
   - tornado=5.1.1=py27h14c3975_1000
-  - traitlets=4.3.2=py27_1000
-  - wcwidth=0.1.7=py_1
+  - traitlets=4.3.3=py27_0
+  - wcwidth=0.1.8=py_0
   - wheel=0.33.6=py27_0
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,101 +1,113 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-09-13 19:47:35 UTC
+# Frozen on 2020-01-27 12:30:09 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - _libgcc_mutex=0.1=main
-  - alembic=1.1.0=py_0
-  - asn1crypto=0.24.0=py36_1003
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=0_gnu
+  - alembic=1.3.3=py_0
   - async_generator=1.10=py_0
-  - attrs=19.1.0=py_0
+  - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
   - blinker=1.4=py_1
-  - ca-certificates=2019.9.11=hecc5488_0
-  - certifi=2019.9.11=py36_0
+  - ca-certificates=2019.11.28=hecc5488_0
+  - certifi=2019.11.28=py36_0
   - certipy=0.1.3=py_0
-  - cffi=1.12.3=py36h8022711_0
+  - cffi=1.13.2=py36h8022711_0
   - chardet=3.0.4=py36_1003
-  - configurable-http-proxy=4.1.0=node11_1
-  - cryptography=2.7=py36h72c5cf5_0
-  - decorator=4.4.0=py_0
-  - defusedxml=0.5.0=py_1
+  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
+  - cryptography=2.8=py36h72c5cf5_1
+  - decorator=4.4.1=py_0
+  - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py36_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
-  - ipykernel=5.1.2=py36h5ca1d4c_0
-  - ipython=7.8.0=py36h5ca1d4c_0
+  - importlib_metadata=1.4.0=py36_0
+  - inflect=4.0.0=py36_1
+  - ipykernel=5.1.3=py36h5ca1d4c_0
+  - ipython=7.11.1=py36h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.15.1=py36_0
-  - jinja2=2.10.1=py_0
-  - jsonschema=3.0.2=py36_0
-  - jupyter_client=5.3.1=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterhub=1.0.0=py36_0
+  - jaraco.itertools=5.0.0=py_0
+  - jedi=0.16.0=py36_0
+  - jinja2=2.10.3=py_0
+  - jsonschema=3.2.0=py36_0
+  - jupyter_client=5.3.4=py36_1
+  - jupyter_core=4.6.1=py36_0
+  - jupyter_telemetry=0.0.4=py_0
+  - jupyterhub=1.1.0=py36_0
   - jupyterlab=0.35.4=py36_0
   - jupyterlab_server=0.2.0=py_0
-  - krb5=1.16.3=h05b26f9_1001
+  - krb5=1.16.4=h2fd8d38_0
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.2.0=h24d8f2e_2
+  - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
-  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py36h14c3975_0
-  - mistune=0.8.4=py36h14c3975_1000
+  - markupsafe=1.1.1=py36h516909a_0
+  - mistune=0.8.4=py36h516909a_1000
+  - more-itertools=8.1.0=py_0
   - nbconvert=5.4.1=py_2
-  - nbformat=4.4.0=py_1
+  - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=11.14.0=he1b5a44_1
+  - nodejs=13.7.0=h10a4023_0
   - notebook=5.7.8=py36_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1c=h516909a_0
+  - openssl=1.1.1d=h516909a_0
   - pamela=1.0.0=py_0
-  - pandoc=2.7.3=0
+  - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.5.1=py_0
-  - pexpect=4.7.0=py36_0
+  - parso=0.6.0=py_0
+  - pexpect=4.8.0=py36_0
   - pickleshare=0.7.5=py36_1000
-  - pip=19.2.3=py36_0
+  - pip=20.0.2=py36_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=2.0.9=py_0
+  - prompt_toolkit=3.0.2=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py36_1
-  - pycurl=7.43.0.2=py36h16ce93b_1
-  - pygments=2.4.2=py_0
+  - pycurl=7.43.0.4=py36h16ce93b_0
+  - pygments=2.5.2=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.0.0=py36_0
-  - pyrsistent=0.15.4=py36h516909a_0
-  - pysocks=1.7.0=py36_0
-  - python=3.6.7=h357f687_1005
-  - python-dateutil=2.8.0=py_0
+  - pyopenssl=19.1.0=py36_0
+  - pyrsistent=0.15.7=py36h516909a_0
+  - pysocks=1.7.1=py36_0
+  - python=3.6.7=h357f687_1006
+  - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
-  - pyzmq=18.1.0=py36h1768529_0
+  - python-json-logger=0.1.11=py_0
+  - pyzmq=18.1.1=py36h1768529_0
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py36_1
+  - ruamel.yaml=0.16.6=py36h516909a_0
+  - ruamel.yaml.clib=0.2.0=py36h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=41.2.0=py36_0
-  - six=1.12.0=py36_1000
-  - sqlalchemy=1.3.8=py36h516909a_0
-  - sqlite=3.29.0=hcee41ef_1
-  - terminado=0.8.2=py36_0
-  - testpath=0.4.2=py_1001
-  - tk=8.6.9=hed695b0_1003
+  - setuptools=45.1.0=py36_0
+  - six=1.14.0=py36_0
+  - sqlalchemy=1.3.13=py36h516909a_0
+  - sqlite=3.30.1=hcee41ef_0
+  - terminado=0.8.3=py36_0
+  - testpath=0.4.4=py_0
+  - tk=8.6.10=hed695b0_0
   - tornado=6.0.3=py36h516909a_0
-  - traitlets=4.3.2=py36_1000
-  - urllib3=1.25.3=py36_0
-  - wcwidth=0.1.7=py_1
+  - traitlets=4.3.3=py36_0
+  - urllib3=1.25.7=py36_0
+  - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
   - wheel=0.33.6=py36_0
   - widgetsnbextension=3.4.2=py36_1000
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -39,6 +39,7 @@ dependencies:
   - jupyter_core=4.6.1=py36_0
   - jupyter_telemetry=0.0.4=py_0
   - jupyterhub-base=1.1.0=py36_2
+  - jupyterhub-singleuser=1.1.0=py36_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-27 12:30:09 UTC
+# Frozen on 2020-01-29 16:07:07 UTC
 name: r2d
 channels:
   - conda-forge
@@ -19,29 +19,28 @@ dependencies:
   - certipy=0.1.3=py_0
   - cffi=1.13.2=py36h8022711_0
   - chardet=3.0.4=py36_1003
-  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
   - cryptography=2.8=py36h72c5cf5_1
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py36_1000
-  - icu=64.2=he1b5a44_1
   - idna=2.8=py36_1000
-  - importlib_metadata=1.4.0=py36_0
+  - importlib_metadata=1.5.0=py36_0
   - inflect=4.0.0=py36_1
-  - ipykernel=5.1.3=py36h5ca1d4c_0
+  - ipykernel=5.1.4=py36h5ca1d4c_0
   - ipython=7.11.1=py36h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.4.2=py_0
+  - ipywidgets=7.5.1=py_0
   - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py36_0
-  - jinja2=2.10.3=py_0
+  - jinja2=2.11.0=py_0
+  - json5=0.8.5=py_0
   - jsonschema=3.2.0=py36_0
   - jupyter_client=5.3.4=py36_1
   - jupyter_core=4.6.1=py36_0
   - jupyter_telemetry=0.0.4=py_0
-  - jupyterhub=1.1.0=py36_0
-  - jupyterlab=0.35.4=py36_0
-  - jupyterlab_server=0.2.0=py_0
+  - jupyterhub-base=1.1.0=py36_2
+  - jupyterlab=1.2.6=py_0
+  - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
@@ -51,16 +50,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
-  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py36h516909a_0
   - mistune=0.8.4=py36h516909a_1000
-  - more-itertools=8.1.0=py_0
-  - nbconvert=5.4.1=py_2
+  - more-itertools=8.2.0=py_0
+  - nbconvert=5.6.1=py36_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=13.7.0=h10a4023_0
-  - notebook=5.7.8=py36_1
+  - notebook=6.0.3=py36_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1d=h516909a_0
@@ -72,7 +69,7 @@ dependencies:
   - pickleshare=0.7.5=py36_1000
   - pip=20.0.2=py36_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.2=py_0
+  - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py36_1
   - pycurl=7.43.0.4=py36h16ce93b_0
@@ -103,8 +100,8 @@ dependencies:
   - urllib3=1.25.7=py36_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.33.6=py36_0
-  - widgetsnbextension=3.4.2=py36_1000
+  - wheel=0.34.1=py36_0
+  - widgetsnbextension=3.5.1=py36_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zipp=2.1.0=py_0

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -4,7 +4,7 @@ dependencies:
 - python=3.6.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
-- jupyterhub-base==1.1.0
+- jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,10 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-09-13 19:47:35 UTC
+# Generated on 2020-01-27 12:30:09 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.4.2
 - jupyterlab==0.35.4
-- jupyterhub=1.0
+- jupyterhub=1.1.0
 - nbconvert==5.4.1
 - notebook==5.7.8
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,10 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-27 12:30:09 UTC
+# Generated on 2020-01-29 16:07:07 UTC
 dependencies:
 - python=3.6.*
-- ipywidgets==7.4.2
-- jupyterlab==0.35.4
-- jupyterhub=1.1.0
-- nbconvert==5.4.1
-- notebook==5.7.8
+- ipywidgets==7.5.1
+- jupyterlab==1.2.6
+- jupyterhub-base==1.1.0
+- nbconvert==5.6.1
+- notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,102 +1,114 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2019-09-13 19:50:21 UTC
+# Frozen on 2020-01-27 12:32:13 UTC
 name: r2d
 channels:
   - conda-forge
   - defaults
   - conda-forge/label/broken
 dependencies:
-  - _libgcc_mutex=0.1=main
-  - alembic=1.1.0=py_0
-  - asn1crypto=0.24.0=py37_1003
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=0_gnu
+  - alembic=1.3.3=py_0
   - async_generator=1.10=py_0
-  - attrs=19.1.0=py_0
+  - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
   - bleach=3.1.0=py_0
   - blinker=1.4=py_1
-  - bzip2=1.0.8=h516909a_1
-  - ca-certificates=2019.9.11=hecc5488_0
-  - certifi=2019.9.11=py37_0
+  - ca-certificates=2019.11.28=hecc5488_0
+  - certifi=2019.11.28=py37_0
   - certipy=0.1.3=py_0
-  - cffi=1.12.3=py37h8022711_0
+  - cffi=1.13.2=py37h8022711_0
   - chardet=3.0.4=py37_1003
-  - configurable-http-proxy=4.1.0=node11_1
-  - cryptography=2.7=py37h72c5cf5_0
-  - decorator=4.4.0=py_0
-  - defusedxml=0.5.0=py_1
+  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
+  - cryptography=2.8=py37h72c5cf5_1
+  - decorator=4.4.1=py_0
+  - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
+  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
-  - ipykernel=5.1.2=py37h5ca1d4c_0
-  - ipython=7.8.0=py37h5ca1d4c_0
+  - importlib_metadata=1.4.0=py37_0
+  - inflect=4.0.0=py37_1
+  - ipykernel=5.1.3=py37h5ca1d4c_0
+  - ipython=7.11.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.4.2=py_0
-  - jedi=0.15.1=py37_0
-  - jinja2=2.10.1=py_0
-  - jsonschema=3.0.2=py37_0
-  - jupyter_client=5.3.1=py_0
-  - jupyter_core=4.4.0=py_0
-  - jupyterhub=1.0.0=py37_0
+  - jaraco.itertools=5.0.0=py_0
+  - jedi=0.16.0=py37_0
+  - jinja2=2.10.3=py_0
+  - jsonschema=3.2.0=py37_0
+  - jupyter_client=5.3.4=py37_1
+  - jupyter_core=4.6.1=py37_0
+  - jupyter_telemetry=0.0.4=py_0
+  - jupyterhub=1.1.0=py37_0
   - jupyterlab=0.35.4=py37_0
   - jupyterlab_server=0.2.0=py_0
-  - krb5=1.16.3=h05b26f9_1001
+  - krb5=1.16.4=h2fd8d38_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
-  - libgcc-ng=9.1.0=hdf63c60_0
+  - libgcc-ng=9.2.0=h24d8f2e_2
+  - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
-  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libstdcxx-ng=9.2.0=hdf63c60_2
+  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py37h14c3975_0
-  - mistune=0.8.4=py37h14c3975_1000
+  - markupsafe=1.1.1=py37h516909a_0
+  - mistune=0.8.4=py37h516909a_1000
+  - more-itertools=8.1.0=py_0
   - nbconvert=5.4.1=py_2
-  - nbformat=4.4.0=py_1
+  - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=11.14.0=he1b5a44_1
+  - nodejs=13.7.0=h10a4023_0
   - notebook=5.7.8=py37_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1c=h516909a_0
+  - openssl=1.1.1d=h516909a_0
   - pamela=1.0.0=py_0
-  - pandoc=2.7.3=0
+  - pandoc=2.9.1.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.5.1=py_0
-  - pexpect=4.7.0=py37_0
+  - parso=0.6.0=py_0
+  - pexpect=4.8.0=py37_0
   - pickleshare=0.7.5=py37_1000
-  - pip=19.2.3=py37_0
+  - pip=20.0.2=py37_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=2.0.9=py_0
+  - prompt_toolkit=3.0.2=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py37_1
-  - pycurl=7.43.0.2=py37h16ce93b_1
-  - pygments=2.4.2=py_0
+  - pycurl=7.43.0.4=py37h16ce93b_0
+  - pygments=2.5.2=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.0.0=py37_0
-  - pyrsistent=0.15.4=py37h516909a_0
-  - pysocks=1.7.0=py37_0
-  - python=3.7.3=h33d41f4_1
-  - python-dateutil=2.8.0=py_0
+  - pyopenssl=19.1.0=py37_0
+  - pyrsistent=0.15.7=py37h516909a_0
+  - pysocks=1.7.1=py37_0
+  - python=3.7.6=h357f687_2
+  - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
-  - pyzmq=18.1.0=py37h1768529_0
+  - python-json-logger=0.1.11=py_0
+  - pyzmq=18.1.1=py37h1768529_0
   - readline=8.0=hf8c457e_0
   - requests=2.22.0=py37_1
+  - ruamel.yaml=0.16.6=py37h516909a_0
+  - ruamel.yaml.clib=0.2.0=py37h516909a_0
   - send2trash=1.5.0=py_0
-  - setuptools=41.2.0=py37_0
-  - six=1.12.0=py37_1000
-  - sqlalchemy=1.3.8=py37h516909a_0
-  - sqlite=3.29.0=hcee41ef_1
-  - terminado=0.8.2=py37_0
-  - testpath=0.4.2=py_1001
-  - tk=8.6.9=hed695b0_1003
+  - setuptools=45.1.0=py37_0
+  - six=1.14.0=py37_0
+  - sqlalchemy=1.3.13=py37h516909a_0
+  - sqlite=3.30.1=hcee41ef_0
+  - terminado=0.8.3=py37_0
+  - testpath=0.4.4=py_0
+  - tk=8.6.10=hed695b0_0
   - tornado=6.0.3=py37h516909a_0
-  - traitlets=4.3.2=py37_1000
-  - urllib3=1.25.3=py37_0
-  - wcwidth=0.1.7=py_1
+  - traitlets=4.3.3=py37_0
+  - urllib3=1.25.7=py37_0
+  - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
   - wheel=0.33.6=py37_0
   - widgetsnbextension=3.4.2=py37_1000
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
+  - zipp=2.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -39,6 +39,7 @@ dependencies:
   - jupyter_core=4.6.1=py37_0
   - jupyter_telemetry=0.0.4=py_0
   - jupyterhub-base=1.1.0=py37_2
+  - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
   - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-27 12:32:13 UTC
+# Frozen on 2020-01-29 16:12:17 UTC
 name: r2d
 channels:
   - conda-forge
@@ -19,31 +19,30 @@ dependencies:
   - certipy=0.1.3=py_0
   - cffi=1.13.2=py37h8022711_0
   - chardet=3.0.4=py37_1003
-  - configurable-http-proxy=4.2.0=node13_he01fd0c_2
   - cryptography=2.8=py37h72c5cf5_1
   - decorator=4.4.1=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37_1000
-  - icu=64.2=he1b5a44_1
   - idna=2.8=py37_1000
-  - importlib_metadata=1.4.0=py37_0
+  - importlib_metadata=1.5.0=py37_0
   - inflect=4.0.0=py37_1
-  - ipykernel=5.1.3=py37h5ca1d4c_0
+  - ipykernel=5.1.4=py37h5ca1d4c_0
   - ipython=7.11.1=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.4.2=py_0
+  - ipywidgets=7.5.1=py_0
   - jaraco.itertools=5.0.0=py_0
   - jedi=0.16.0=py37_0
-  - jinja2=2.10.3=py_0
+  - jinja2=2.11.0=py_0
+  - json5=0.8.5=py_0
   - jsonschema=3.2.0=py37_0
   - jupyter_client=5.3.4=py37_1
   - jupyter_core=4.6.1=py37_0
   - jupyter_telemetry=0.0.4=py_0
-  - jupyterhub=1.1.0=py37_0
-  - jupyterlab=0.35.4=py37_0
-  - jupyterlab_server=0.2.0=py_0
+  - jupyterhub-base=1.1.0=py37_2
+  - jupyterlab=1.2.6=py_0
+  - jupyterlab_server=1.0.6=py_0
   - krb5=1.16.4=h2fd8d38_0
-  - ld_impl_linux-64=2.33.1=h53a641e_7
+  - ld_impl_linux-64=2.33.1=h53a641e_8
   - libcurl=7.65.3=hda55be3_0
   - libedit=3.1.20170329=hf8c457e_1001
   - libffi=3.2.1=he1b5a44_1006
@@ -52,16 +51,14 @@ dependencies:
   - libsodium=1.0.17=h516909a_0
   - libssh2=1.8.2=h22169c7_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
-  - libuv=1.34.0=h516909a_0
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h516909a_0
   - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.1.0=py_0
-  - nbconvert=5.4.1=py_2
+  - more-itertools=8.2.0=py_0
+  - nbconvert=5.6.1=py37_0
   - nbformat=5.0.4=py_0
   - ncurses=6.1=hf484d3e_1002
-  - nodejs=13.7.0=h10a4023_0
-  - notebook=5.7.8=py37_1
+  - notebook=6.0.3=py37_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1d=h516909a_0
@@ -73,7 +70,7 @@ dependencies:
   - pickleshare=0.7.5=py37_1000
   - pip=20.0.2=py37_0
   - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.2=py_0
+  - prompt_toolkit=3.0.3=py_0
   - ptyprocess=0.6.0=py_1001
   - pycparser=2.19=py37_1
   - pycurl=7.43.0.4=py37h16ce93b_0
@@ -104,8 +101,8 @@ dependencies:
   - urllib3=1.25.7=py37_0
   - wcwidth=0.1.8=py_0
   - webencodings=0.5.1=py_1
-  - wheel=0.33.6=py37_0
-  - widgetsnbextension=3.4.2=py37_1000
+  - wheel=0.34.1=py37_0
+  - widgetsnbextension=3.5.1=py37_0
   - xz=5.2.4=h14c3975_1001
   - zeromq=4.3.2=he1b5a44_2
   - zipp=2.1.0=py_0

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,10 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-27 12:32:13 UTC
+# Generated on 2020-01-29 16:12:17 UTC
 dependencies:
 - python=3.7.*
-- ipywidgets==7.4.2
-- jupyterlab==0.35.4
-- jupyterhub=1.1.0
-- nbconvert==5.4.1
-- notebook==5.7.8
+- ipywidgets==7.5.1
+- jupyterlab==1.2.6
+- jupyterhub-base==1.1.0
+- nbconvert==5.6.1
+- notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -4,7 +4,7 @@ dependencies:
 - python=3.7.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
-- jupyterhub-base==1.1.0
+- jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,10 +1,10 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2019-09-13 19:50:21 UTC
+# Generated on 2020-01-27 12:32:13 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.4.2
 - jupyterlab==0.35.4
-- jupyterhub=1.0
+- jupyterhub=1.1.0
 - nbconvert==5.4.1
 - notebook==5.7.8
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -2,7 +2,7 @@ dependencies:
   - python=3.7
   - ipywidgets==7.4.2
   - jupyterlab==0.35.4
-  - jupyterhub=1.0
+  - jupyterhub=1.1.0
   - nbconvert==5.4.1
   - notebook==5.7.8
   - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -2,7 +2,7 @@ dependencies:
   - python=3.7
   - ipywidgets==7.5.1
   - jupyterlab==1.2.6
-  - jupyterhub-base==1.1.0
+  - jupyterhub-singleuser==1.1.0
   - nbconvert==5.6.1
   - notebook==6.0.3
   - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,8 +1,8 @@
 dependencies:
   - python=3.7
-  - ipywidgets==7.4.2
-  - jupyterlab==0.35.4
-  - nbconvert==5.4.1
-  - notebook==5.7.8
+  - ipywidgets==7.5.1
+  - jupyterlab==1.2.6
   - jupyterhub-base==1.1.0
+  - nbconvert==5.6.1
+  - notebook==6.0.3
   - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -2,7 +2,7 @@ dependencies:
   - python=3.7
   - ipywidgets==7.4.2
   - jupyterlab==0.35.4
-  - jupyterhub=1.1.0
   - nbconvert==5.4.1
   - notebook==5.7.8
+  - jupyterhub-base==1.1.0
   - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/julia/julia_require.py
+++ b/repo2docker/buildpacks/julia/julia_require.py
@@ -1,5 +1,8 @@
 """Generates a Dockerfile based on an input matrix with REQUIRE for legacy Julia"""
+
+from distutils.version import LooseVersion as V
 import os
+
 from ..python import PythonBuildPack
 
 
@@ -10,6 +13,16 @@ class JuliaRequireBuildPack(PythonBuildPack):
 
     minor_julias = {"0.6": "0.6.4", "0.7": "0.7.0", "1.0": "1.0.4", "1.1": "1.1.1"}
     major_julias = {"1": "1.1.1"}
+
+    @property
+    def python_version(self):
+        # IJulia doesn't build on julia 0.6
+        # due to old incompatibilities with Jupyter-core >= 4.5,
+        # so use the similarly-old Python 3.5 base environment
+        if V(self.julia_version) < V("0.7"):
+            return "3.5"
+        else:
+            return super().python_version
 
     @property
     def julia_version(self):

--- a/tests/base/node10/verify
+++ b/tests/base/node10/verify
@@ -1,13 +1,11 @@
 #!/bin/sh
 
-set -e
-# check node from conda-forge
+set -ex
+
+# check node system package and its version
 which node
 node --version
-node --version | grep v11
-# check node system package
-/usr/bin/node --version
-/usr/bin/node --version | grep v10
+node --version | grep v10
 
 which npm
 npm --version


### PR DESCRIPTION
- jupyterhub 1.1 (includes #832)
- notebook 6
- nbconvert 5.6
- jupyterlab 1.2
- widgets 7.5

switch to new jupyterhub-base package which doesn't depend on unused configurable-http-proxy and node.js, and should reduce confusion about two nodes being installed. I think this fixes recent CI failures associated with a newer release of node on conda-forge.


<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->