### PR TITLE
docs: postBuild warn about shell script errors being ignored

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -176,6 +176,9 @@ To see example repositories, visit our
 A script that can contain arbitrary commands to be run after the whole repository has been built. If you
 want this to be a shell script, make sure the first line is ``#!/bin/bash``.
 
+Note that by default the build will not be stopped if an error occurs inside a shell script.
+You should include ``set -e`` or the equivalent at the start of the script to avoid errors being silently ignored.
+
 An example use-case of ``postBuild`` file is JupyterLab's demo on mybinder.org.
 It uses a ``postBuild`` file in a folder called ``binder`` to `prepare
 their demo for binder <https://github.com/jupyterlab/jupyterlab-demo/blob/master/binder/postBuild>`_.


### PR DESCRIPTION
This may be obvious in hindsight, but it's easy to forget since problems anywhere else will abort the build.