### PR TITLE
[MRG] Add jupyter-offlinenotebook extension

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -54,8 +54,9 @@ conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 # after the server connection has been lost
 # This will install and enable the extension for jupyter notebook
 ${NB_PYTHON_PREFIX}/bin/python -m pip install https://github.com/manics/jupyter-offlinenotebook/archive/7ba3520.zip
-# and this installs it for lab
-${NB_PYTHON_PREFIX}/bin/jupyter labextension install jupyter-offlinenotebook
+# and this installs it for lab. Keep going if the lab version is incompatible
+# with the extension
+${NB_PYTHON_PREFIX}/bin/jupyter labextension install jupyter-offlinenotebook || true
 
 # empty conda history file,
 # which seems to result in some effective pinning of packages in the initial env,

--- a/repo2docker/buildpacks/conda/install-miniconda.bash
+++ b/repo2docker/buildpacks/conda/install-miniconda.bash
@@ -50,6 +50,13 @@ echo "installing notebook env:"
 cat /tmp/environment.yml
 conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 
+# Install jupyter-offline-notebook to allow users to download notebooks
+# after the server connection has been lost
+# This will install and enable the extension for jupyter notebook
+${NB_PYTHON_PREFIX}/bin/python -m pip install https://github.com/manics/jupyter-offlinenotebook/archive/7ba3520.zip
+# and this installs it for lab
+${NB_PYTHON_PREFIX}/bin/jupyter labextension install jupyter-offlinenotebook
+
 # empty conda history file,
 # which seems to result in some effective pinning of packages in the initial env,
 # which we don't intend.


### PR DESCRIPTION
This adds the offlinenotebook extension to the base install. With this
users can download their notebook even after the server has gone away.

The extension came out of ideas in https://github.com/jupyterhub/binderhub/issues/1003.

I think we should give this a try and see what people say to it. You can demo it on https://github.com/manics/jupyter-offlinenotebook (has a binder link).