### PR TITLE
[MRG] Update black 19.10b0, target Python 3.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 19.10b0
   hooks:
   - id: black
+    args: [--target-version=py35]


### PR DESCRIPTION
In https://github.com/jupyter/repo2docker/pull/848 I ran into problems with black auto-formatting some new code in a way that incompatible with Python 3.5 (I think this issue is related: https://github.com/psf/black/issues/419).

It looks like this is fixed in the latest black.