### PR TITLE
[MRG] utils.execute_cmd flush buffer if no EOL

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -50,6 +50,8 @@ def execute_cmd(cmd, capture=False, **kwargs):
             if c == b"\n":
                 yield flush()
             c_last = c
+        if buf:
+            yield flush()
     finally:
         ret = proc.wait()
         if ret != 0:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,6 +27,14 @@ def test_capture_cmd_capture_success():
         assert line == "test\n"
 
 
+def test_capture_cmd_noeol_capture_success():
+    # This should succeed
+    lines = list(
+        utils.execute_cmd(["/bin/bash", "-c", "echo -en 'test\ntest'"], capture=True)
+    )
+    assert lines == ["test\n", "test"]
+
+
 def test_capture_cmd_capture_fail():
     with pytest.raises(subprocess.CalledProcessError):
         for line in utils.execute_cmd(


### PR DESCRIPTION
Extracted from #806 

Older versions of Podman occasionally failed to terminate their output with a newline. This resulted in a bug due to `execute_cmd` not flushing the final line of the buffered stdout if it didn't end with a newline.

Current versions of Podman seem to work without this fix, however if repo2docker is further extended in future it would be good to avoid someone else hitting this bug.