### PR TITLE
[MRG] If looking for latest MRAN URL try earlier snapshots too

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -1,6 +1,7 @@
 import re
 import os
 import datetime
+import requests
 
 from distutils.version import LooseVersion as V
 
@@ -135,8 +136,9 @@ class RBuildPack(PythonBuildPack):
                 # no R snapshot date set through runtime.txt
                 # set the R runtime to the latest date that is guaranteed to
                 # be on MRAN across timezones
-                self._checkpoint_date = datetime.date.today() - datetime.timedelta(
-                    days=2
+                two_days_ago = datetime.date.today() - datetime.timedelta(days=2)
+                self._checkpoint_date = self._get_latest_working_mran_date(
+                    two_days_ago, 3
                 )
                 self._runtime = "r-{}".format(str(self._checkpoint_date))
             return True
@@ -185,6 +187,29 @@ class RBuildPack(PythonBuildPack):
             packages.append("libclang-dev")
 
         return super().get_packages().union(packages)
+
+    def _get_latest_working_mran_date(self, startdate, max_prior):
+        """
+        Look for a working MRAN snapshot
+
+        Starts from `startdate` and tries up to `max_prior` previous days.
+        Raises `requests.HTTPError` with the last tried URL if no working snapshot found.
+        """
+        for days in range(0, max_prior + 1):
+            test_date = startdate - datetime.timedelta(days=days)
+            mran_url = "https://mran.microsoft.com/snapshot/{}".format(
+                test_date.isoformat()
+            )
+            r = requests.head(mran_url)
+            if r.ok:
+                return test_date
+            self.log.warning(
+                "Failed to get MRAN snapshot URL %s: %s %s",
+                mran_url,
+                r.status_code,
+                r.reason,
+            )
+        r.raise_for_status()
 
     def get_build_scripts(self):
         """

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -195,7 +195,7 @@ class RBuildPack(PythonBuildPack):
         Starts from `startdate` and tries up to `max_prior` previous days.
         Raises `requests.HTTPError` with the last tried URL if no working snapshot found.
         """
-        for days in range(0, max_prior + 1):
+        for days in range(max_prior + 1):
             test_date = startdate - datetime.timedelta(days=days)
             mran_url = "https://mran.microsoft.com/snapshot/{}".format(
                 test_date.isoformat()


### PR DESCRIPTION
Related to https://github.com/jupyter/repo2docker/issues/773#issuecomment-586571022

The particular issue I ran into today is a missing "latest" MRAN snapshot in the Travis R tests. This PR automatically tries older snapshots in this case.

What's not clear to me from the linked issue is whether the test failures mostly occur due to a missing latest snapshot (this PR should help), or whether it's due to a broken MRAN server for a snapshot that definitely exists.

Example:
```
$ repo2docker tests/r/description-file/
Picked Local content provider.
Using local repo tests/r/description-file/.
Failed to get MRAN snapshot URL https://mran.microsoft.com/snapshot/2020-02-13: 404 Not Found
Using RBuildPack builder
```