### PR TITLE
Use miniforge instead of miniconda to get conda

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -63,7 +63,7 @@ class CondaBuildPack(BaseImage):
 
         All scripts here should be independent of contents of the repository.
 
-        This sets up through `install-miniconda.bash` (found in this directory):
+        This sets up through `install-miniforge.bash` (found in this directory):
 
         - a directory for the conda environment and its ownership by the
           notebook user
@@ -79,8 +79,8 @@ class CondaBuildPack(BaseImage):
             (
                 "root",
                 r"""
-                bash /tmp/install-miniconda.bash && \
-                rm /tmp/install-miniconda.bash /tmp/environment.yml
+                bash /tmp/install-miniforge.bash && \
+                rm /tmp/install-miniforge.bash /tmp/environment.yml
                 """,
             )
         ]
@@ -103,7 +103,7 @@ class CondaBuildPack(BaseImage):
 
         """
         files = {
-            "conda/install-miniconda.bash": "/tmp/install-miniconda.bash",
+            "conda/install-miniforge.bash": "/tmp/install-miniforge.bash",
             "conda/activate-conda.sh": "/etc/profile.d/activate-conda.sh",
         }
         py_version = self.python_version

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -20,7 +20,7 @@ chmod +x ${INSTALLER_PATH}
 
 # check sha256 checksum
 if ! echo "${SHA256SUM}  ${INSTALLER_PATH}" | sha256sum  --quiet -c -; then
-    echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
+    echo "sha256 mismatch for ${INSTALLER_PATH}, exiting!"
     exit 1
 fi
 

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -26,6 +26,9 @@ fi
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
+# Preserve behavior of miniconda - packages come from conda-forge + defaults
+conda config --system --add channels defaults
+
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
 conda config --system --set show_channel_urls true

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -4,11 +4,10 @@ set -ex
 
 cd $(dirname $0)
 MINIFORGE_VERSION=4.8.2-1
-CONDA_VERSION=4.8.2
 # SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
 SHA256SUM="4f897e503bd0edfb277524ca5b6a5b14ad818b3198c2f07a36858b7d88c928db"
 
-URL="https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh"
+URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniforge-installer.sh
 
 # make sure we don't do anything funky with user's $HOME
@@ -33,14 +32,6 @@ conda config --system --set show_channel_urls true
 
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
-
-# install conda itself, if needed
-# FIXME: MINIFORGE_VERSION might have a build number, like -1.
-# This will force conda to be installed each time
-# Use a better way of finding conda version!
-if [[ "${CONDA_VERSION}" != "${MINIFORGE_VERSION}" ]]; then
-    conda install -yq conda==${CONDA_VERSION}
-fi
 
 # avoid future changes to default channel_priority behavior
 conda config --system --set channel_priority "flexible"

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -3,14 +3,13 @@
 set -ex
 
 cd $(dirname $0)
-MINICONDA_VERSION=4.7.12.1
-CONDA_VERSION=4.7.12
-# Only MD5 checksums are available for miniconda
-# Can be obtained from https://repo.continuum.io/miniconda/
-MD5SUM="81c773ff87af5cfac79ab862942ab6b3"
+MINIFORGE_VERSION=4.8.2-1
+CONDA_VERSION=4.8.2
+# SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
+SHA256SUM="4f897e503bd0edfb277524ca5b6a5b14ad818b3198c2f07a36858b7d88c928db"
 
-URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
-INSTALLER_PATH=/tmp/miniconda-installer.sh
+URL="https://github.com/conda-forge/miniforge/releases/download/4.8.2-1/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh"
+INSTALLER_PATH=/tmp/miniforge-installer.sh
 
 # make sure we don't do anything funky with user's $HOME
 # since this is run as root
@@ -19,17 +18,14 @@ unset HOME
 wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
-# check md5 checksum
-if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
+# check sha256 checksum
+if ! echo "${SHA256SUM}  ${INSTALLER_PATH}" | sha256sum  --quiet -c -; then
     echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
     exit 1
 fi
 
 bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
-
-# Allow easy direct installs from conda forge
-conda config --system --add channels conda-forge
 
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false
@@ -38,8 +34,11 @@ conda config --system --set show_channel_urls true
 # bug in conda 4.3.>15 prevents --set update_dependencies
 echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 
-# install conda itself
-if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
+# install conda itself, if needed
+# FIXME: MINIFORGE_VERSION might have a build number, like -1.
+# This will force conda to be installed each time
+# Use a better way of finding conda version!
+if [[ "${CONDA_VERSION}" != "${MINIFORGE_VERSION}" ]]; then
     conda install -yq conda==${CONDA_VERSION}
 fi
 
@@ -81,7 +80,7 @@ conda clean --all -f -y
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
 
-# Remove the pip cache created as part of installing miniconda
+# Remove the pip cache created as part of installing miniforge
 rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -27,7 +27,7 @@ bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
 # Preserve behavior of miniconda - packages come from conda-forge + defaults
-conda config --system --add channels defaults
+conda config --system --append channels defaults
 
 # Do not attempt to auto update conda or dependencies
 conda config --system --set auto_update_conda false

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,6 +5,6 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["conda", "--version"]).decode("utf8").strip()
-assert out == "conda 4.7.12", out
+assert out == "conda 4.8.2", out
 
 import numpy


### PR DESCRIPTION
[miniforge](https://github.com/conda-forge/miniforge) is a new
community-led installer that uses conda-forge as the default
channel, rather than defaults. This gives us a few advantages:

- No mixing of defaults & conda-forge channel by default. My
  intuition is that this will reduce image size & build times,
  but I don't know enough about conda to say if this is real
- It provides installers for architectures unsupported by miniconda.
  This is particularly useful important for ARM & PowerPC, when we
  want to support those better.
- I like conda-forge, and we should do what we can to support them!
  This is a fairly easy, drop-in way to do so
- It is more likely to have newer versions of conda by default
  than miniconda
- It provides sha256 hashes for installers rather than just md5. This
  makes me personally happy

There should be no user-facing changes here as far as I can tell.

Fixes #858

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
