### PR TITLE
[MRG] Fix long form args requirements

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -466,7 +466,15 @@ def is_local_pip_requirement(line):
     if line.startswith(("-r", "-c")):
         # local -r or -c references break isolation
         return True
-    # strip off `-e, etc.`
+    if line.startswith(("--requirement", "--constraint")):
+        # as above but flags are spelt out
+        return True
+    # strip off things like `--editable=`. Long form arguments require a =
+    if line.startswith("--"):
+        line = line.split("=", 1)[1]
+    # strip off short form arguments like `-e`. Short form arguments can be
+    # followed by a space `-e foo` or use `-e=foo`. The latter is not handled
+    # here. We can deal with it when we see someone using it.
     if line.startswith("-"):
         line = line.split(None, 1)[1]
     if "file://" in line:

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -64,9 +64,7 @@ def test_mran_date(tmpdir, runtime, expected):
     assert r.checkpoint_date == date(*expected)
 
 
-@pytest.mark.parametrize(
-    "expected", ["2019-12-29", "2019-12-26"],
-)
+@pytest.mark.parametrize("expected", ["2019-12-29", "2019-12-26"])
 def test_mran_latestdate(tmpdir, expected):
     def mock_request_head(url):
         r = Response()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -135,6 +135,7 @@ def test_open_guess_encoding():
     [
         ("-r requirements.txt", True),
         ("-e .", True),
+        ("--editable=.", True),
         ("file://subdir", True),
         ("file://./subdir", True),
         ("git://github.com/jupyter/repo2docker", False),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -136,6 +136,10 @@ def test_open_guess_encoding():
         ("-r requirements.txt", True),
         ("-e .", True),
         ("--editable=.", True),
+        (
+            "--editable=git+https://github.com/popgensims/stdpopsim.git#egg=stdpopsim-master",
+            False,
+        ),
         ("file://subdir", True),
         ("file://./subdir", True),
         ("git://github.com/jupyter/repo2docker", False),


### PR DESCRIPTION
https://github.com/agladstein/stdpopsim/blob/binder/environment.yml#L20 uses a complex argument that our parsing of lines didn't handle. 

This PR makes our heuristic a bit smarter, but there are probably still cases we don't handle. I'd propose punting on them until we encounter them in the wild.

@agladstein this should fix the bug your reported in gitter earlier.