### PR TITLE
[MRG] Update server proxy and rsession proxy

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -55,7 +55,7 @@ def rstudio_base_scripts():
             "${NB_USER}",
             # Install nbrsessionproxy
             r"""
-                pip install --no-cache-dir https://github.com/jupyterhub/jupyter-server-proxy/archive/00be53dfed8ab5a0baaf8332e3fc6bd44dc5bf1a.zip && \
+                pip install --no-cache-dir jupyter-server-proxy==1.3.2 && \
                 pip install --no-cache-dir https://github.com/jupyterhub/jupyter-rsession-proxy/archive/d5efed5455870556fc414f30871d0feca675a4b4.zip && \
                 jupyter serverextension enable jupyter_server_proxy --sys-prefix && \
                 jupyter nbextension install --py jupyter_server_proxy --sys-prefix && \

--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -55,8 +55,8 @@ def rstudio_base_scripts():
             "${NB_USER}",
             # Install nbrsessionproxy
             r"""
-                pip install --no-cache-dir https://github.com/jupyterhub/jupyter-server-proxy/archive/7ac0125.zip && \
-                pip install --no-cache-dir jupyter-rsession-proxy==1.0b6 && \
+                pip install --no-cache-dir https://github.com/jupyterhub/jupyter-server-proxy/archive/00be53dfed8ab5a0baaf8332e3fc6bd44dc5bf1a.zip && \
+                pip install --no-cache-dir https://github.com/jupyterhub/jupyter-rsession-proxy/archive/d5efed5455870556fc414f30871d0feca675a4b4.zip && \
                 jupyter serverextension enable jupyter_server_proxy --sys-prefix && \
                 jupyter nbextension install --py jupyter_server_proxy --sys-prefix && \
                 jupyter nbextension enable --py jupyter_server_proxy --sys-prefix


### PR DESCRIPTION
Both haven't been updated in a long time (~1yr) so we should refresh
them. This brings both to the latest commit in their repos.

Can anyone remember if there were big changes in either that would break things for users of repo2docker?