### PR TITLE
[docs] fix grammatical error in section title

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -56,7 +56,7 @@ file.
 We support R versions 3.4, 3.5 and 3.6.
 
 
-Why is my repository is failing to build with ``ResolvePackageNotFound`` ?
+Why is my repository failing to build with ``ResolvePackageNotFound`` ?
 --------------------------------------------------------------------------
 
 If you used ``conda env export`` to generate your ``environment.yml`` it will
@@ -133,7 +133,7 @@ This builds a Docker container from the files in that repository
 then runs that container, while connecting the working directory
 inside the container to the local repository outside the
 container. For example, in case there is a notebook file (``.ipynb``),
-this will open in a local webbrowser, and one can edit it and save
+this will open in a local web browser, and one can edit it and save
 it. The resulting notebook is updated in both the Docker container and
 the local repository. Once the container is exited, the changed file
 will still be in the local repository.


### PR DESCRIPTION
Thanks for this great project! I noticed two minor grammatical issues [in the FAQs](https://repo2docker.readthedocs.io/en/latest/faq.html#why-is-my-repository-is-failing-to-build-with-resolvepackagenotfound) today, and in this PR I propose fixes for them.

Thanks for your time and consideration.