### PR TITLE
[MRG] Change --env option to work like docker's

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -158,6 +158,10 @@ def get_argparser():
         "--user-name", help="Username of the primary user in the image"
     )
 
+    # Process the environment options the same way that docker does, as
+    # they are passed directly to docker as the environment to use. This
+    # requires a custom action for argparse.
+    # see https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file
     argparser.add_argument(
         "--env",
         "-e",

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -560,6 +560,8 @@ class Repo2Docker(Application):
                     "mode": "rw",
                 }
 
+        # self.environment needs to be modified to match the semantics
+        # of docker's --env option
         run_kwargs = dict(
             publish_all_ports=self.all_ports,
             ports=ports,

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -560,8 +560,6 @@ class Repo2Docker(Application):
                     "mode": "rw",
                 }
 
-        # self.environment needs to be modified to match the semantics
-        # of docker's --env option
         run_kwargs = dict(
             publish_all_ports=self.all_ports,
             ports=ports,

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -11,26 +11,39 @@ from getpass import getuser
 def test_env():
     """
     Validate that you can define environment variables
+
+    See https://gist.github.com/hwine/9f5b02c894427324fafcf12f772b27b7
+    for how docker handles its -e & --env argument values
     """
     ts = str(time.time())
     with tempfile.TemporaryDirectory() as tmpdir:
         username = getuser()
         os.environ["SPAM"] = "eggs"
+        os.environ["SPAM_2"] = "ham"
         result = subprocess.run(
             [
                 "repo2docker",
+                # 'key=value' are exported as is in docker
                 "-e",
                 "FOO={}".format(ts),
                 "--env",
                 "BAR=baz",
+                # 'key' is exported with the currently exported value
                 "--env",
                 "SPAM",
+                # 'key' is not exported if it is not exported.
+                "-e",
+                "NO_SPAM",
+                # 'key=' is exported in docker with an empty string as
+                # value
+                "--env",
+                "SPAM_2=",
                 "--",
                 tmpdir,
                 "/bin/bash",
                 "-c",
                 # Docker exports all passed env variables, so we can
-                # just look at that output
+                # just look at exported variables.
                 "export",
             ],
             universal_newlines=True,
@@ -38,9 +51,12 @@ def test_env():
             stderr=subprocess.PIPE,
         )
     assert result.returncode == 0
+
     # all docker output is returned by repo2docker on stderr
     # extract just the declare for better failure message formatting
     declares = [x for x in result.stderr.split("\n") if x.startswith("declare")]
     assert 'declare -x FOO="{}"'.format(ts) in declares
     assert 'declare -x BAR="baz"' in declares
     assert 'declare -x SPAM="eggs"' in declares
+    assert "declare -x NO_SPAM" not in declares
+    assert 'declare -x SPAM_2=""' in declares

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -15,6 +15,7 @@ def test_env():
     ts = str(time.time())
     with tempfile.TemporaryDirectory() as tmpdir:
         username = getuser()
+        os.environ["SPAM"] = "eggs"
         subprocess.check_call(
             [
                 "repo2docker",
@@ -24,11 +25,13 @@ def test_env():
                 "FOO={}".format(ts),
                 "--env",
                 "BAR=baz",
+                "--env",
+                "SPAM",
                 "--",
                 tmpdir,
                 "/bin/bash",
                 "-c",
-                "echo -n $FOO > ts && echo -n $BAR > bar",
+                "echo -n $FOO > ts && echo -n $BAR > bar && echo -n $SPAM > eggs",
             ]
         )
 
@@ -36,3 +39,5 @@ def test_env():
             assert f.read().strip() == ts
         with open(os.path.join(tmpdir, "bar")) as f:
             assert f.read().strip() == "baz"
+        with open(os.path.join(tmpdir, "eggs")) as f:
+            assert f.read().strip() == "eggs"


### PR DESCRIPTION
The goal here is make `repo2docker` process the `--env` option with the same semantics as the `--env` option to `docker` itself.

Closes #871