### PR TITLE
[MRG] pypi jupyter-offlinenotebook==0.1.0

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -46,7 +46,7 @@ conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 # Install jupyter-offline-notebook to allow users to download notebooks
 # after the server connection has been lost
 # This will install and enable the extension for jupyter notebook
-${NB_PYTHON_PREFIX}/bin/python -m pip install https://github.com/manics/jupyter-offlinenotebook/archive/7ba3520.zip
+${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.0
 # and this installs it for lab. Keep going if the lab version is incompatible
 # with the extension
 ${NB_PYTHON_PREFIX}/bin/jupyter labextension install jupyter-offlinenotebook || true


### PR DESCRIPTION
Use the latest released version of jupyter-offlinenotebook instead of a commit SHA1.

Related to https://github.com/jupyter/repo2docker/issues/724#issuecomment-616094914