### PR TITLE
[MRG] chmod start script from repo2docker-entrypoint

### DIFF
--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -3,6 +3,7 @@
 # we use a login shell to get a fully configured shell environment
 # (e.g. sourcing /etc/profile.d, ~/.bashrc, and friends)
 if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
+    chmod u+x "$R2D_ENTRYPOINT"
     exec "$R2D_ENTRYPOINT" "$@"
 else
     exec "$@"

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -3,7 +3,9 @@
 # we use a login shell to get a fully configured shell environment
 # (e.g. sourcing /etc/profile.d, ~/.bashrc, and friends)
 if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
-    chmod u+x "$R2D_ENTRYPOINT"
+    if [[ ! -x "$R2D_ENTRYPOINT" ]]; then
+        chmod u+x "$R2D_ENTRYPOINT"
+    fi
     exec "$R2D_ENTRYPOINT" "$@"
 else
     exec "$@"


### PR DESCRIPTION
Discussed in Issue #883 - Make binder/start script not need to be executable

Now repo2docker-entrypoint ensures 'chmod u+x' is applied to the start script specified in $R2D_ENTRYPOINT.

This helps if the chmod applied in the build process doesn't affect the final executed copy of the start script file. For example, if the repo2docker is run as a 'local folder' source which is then mounted at /home/jovyan. The image's copy of the start script had +x set, but not in the local folder itself.

It will also fix start script problems with any repo source within my [ContainDS Desktop](https://containds.com/desktop) 'local binder' software.