### PR TITLE
[MRG] Bump version of irkernel for R 4.0

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -17,7 +17,7 @@ SHINY_CHECKSUM = "9aeef6613e7f58f21c97a4600921340e"
 DEVTOOLS_VERSION = "2018-02-01"
 
 # IRKernel version - specified as a tag in the IRKernel repository
-IRKERNEL_VERSION = "1.0.2"
+IRKERNEL_VERSION = "1.1"
 
 
 def rstudio_base_scripts():


### PR DESCRIPTION
This bumps irkernel to v1.1. With this change https://github.com/betatim/r-conda/tree/betatim-patch-1 builds. Without it conda seems to sit and spin "solving the environment" in different modes for a long time/until after I ran out of patience.

I think bumping the version of irkernel should be harmless/not break things for users who don't care about the version of irkernel.