### PR TITLE
[MRG] Fix RShiny proxy

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -55,8 +55,9 @@ def rstudio_base_scripts():
             "${NB_USER}",
             # Install nbrsessionproxy
             r"""
-                pip install --no-cache-dir jupyter-server-proxy==1.3.2 && \
+                pip install --no-cache-dir jupyter-server-proxy==1.4.0 && \
                 pip install --no-cache-dir https://github.com/jupyterhub/jupyter-rsession-proxy/archive/d5efed5455870556fc414f30871d0feca675a4b4.zip && \
+                pip install --no-cache-dir https://github.com/ryanlovett/jupyter-shiny-proxy/archive/47557dc47e2aeeab490eb5f3eeae414cdde4a6a9.zip && \
                 jupyter serverextension enable jupyter_server_proxy --sys-prefix && \
                 jupyter nbextension install --py jupyter_server_proxy --sys-prefix && \
                 jupyter nbextension enable --py jupyter_server_proxy --sys-prefix


### PR DESCRIPTION
The Shiny proxy was split out of the rstudio proxy package. This meant
that RStudio sessions were still being proxied but Shiny sessions not.

This was found by a user and reported in https://discourse.jupyter.org/t/shiny-applications-getting-redirect-errors/4340