### PR TITLE
Update Dockerfile to add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN mkdir /tmp/wheelhouse \
 FROM alpine:${ALPINE_VERSION}
 
 # install python, git, bash
-RUN apk add --no-cache git git-lfs python3 bash
-RUN apk add docker
+RUN apk add --no-cache git git-lfs python3 bash docker
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM alpine:${ALPINE_VERSION}
 
 # install python, git, bash
 RUN apk add --no-cache git git-lfs python3 bash
+RUN apk add docker
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse


### PR DESCRIPTION
I'm trying to add Docker into the Docker image so that I can run docker-in-docker with repo2docker which will facilitate GitHub Actions I am building at GitHub

I want to use repo2docker to power [codespaces](https://github.com/features/codespaces/) and this unblocks that for me.  I would rather depend on the official Jupyter image rather than maintaining our own.  Having this dependency will also unblock other future features. 

cc: @betatim @willingc 