### PR TITLE
Add Julia 1.4.2 support

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -28,6 +28,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         "1.3.1",
         "1.4.0",
         "1.4.1",
+        "1.4.2",
     ]
 
     @property


### PR DESCRIPTION
Julia 1.4.2 was released today, so this adds support.