### PR TITLE
[MRG] Add nbresuse==0.3.3 (full freeze.py)

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:05 UTC
+# Frozen on 2020-06-02 18:09:38 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,105 +8,109 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
-  - bleach=3.1.0=py_0
+  - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
-  - ca-certificates=2019.11.28=hecc5488_0
-  - certifi=2019.11.28=py37_0
+  - brotlipy=0.7.0=py37h8f50634_1000
+  - ca-certificates=2020.4.5.1=hecc5488_0
+  - certifi=2020.4.5.1=py37hc8dfbb8_0
   - certipy=0.1.3=py_0
-  - cffi=1.13.2=py37h8022711_0
-  - chardet=3.0.4=py37_1003
-  - cryptography=2.8=py37h72c5cf5_1
-  - decorator=4.4.1=py_0
+  - cffi=1.14.0=py37hd463f26_0
+  - chardet=3.0.4=py37hc8dfbb8_1006
+  - cryptography=2.9.2=py37hb09aad4_0
+  - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - entrypoints=0.3=py37_1000
-  - idna=2.8=py37_1000
-  - importlib_metadata=1.5.0=py37_0
-  - inflect=4.0.0=py37_1
-  - ipykernel=5.1.4=py37h5ca1d4c_0
-  - ipython=7.11.1=py37h5ca1d4c_0
+  - entrypoints=0.3=py37hc8dfbb8_1001
+  - idna=2.9=py_1
+  - importlib-metadata=1.6.0=py37hc8dfbb8_0
+  - importlib_metadata=1.6.0=0
+  - ipykernel=5.3.0=py37h43977f1_0
+  - ipython=7.15.0=py37hc8dfbb8_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
-  - jedi=0.16.0=py37_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
-  - jsonschema=3.2.0=py37_0
-  - jupyter_client=5.3.4=py37_1
-  - jupyter_core=4.6.1=py37_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jedi=0.17.0=py37hc8dfbb8_0
+  - jinja2=2.11.2=pyh9f0ad1d_0
+  - json5=0.9.0=py_0
+  - jsonschema=3.2.0=py37hc8dfbb8_1
+  - jupyter_client=6.1.3=py_0
+  - jupyter_core=4.6.3=py37hc8dfbb8_1
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.0.6=py_0
-  - krb5=1.16.4=h2fd8d38_0
-  - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
-  - libedit=3.1.20170329=hf8c457e_1001
-  - libffi=3.2.1=he1b5a44_1006
+  - jupyterlab_server=1.1.5=py_0
+  - krb5=1.17.1=h2fd8d38_0
+  - ld_impl_linux-64=2.34=h53a641e_4
+  - libcurl=7.69.1=hf7181ac_0
+  - libedit=3.1.20191231=h46ee950_0
+  - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.8.2=h22169c7_2
+  - libssh2=1.9.0=hab1572f_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py37h516909a_0
-  - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.2.0=py_0
-  - nbconvert=5.6.1=py37_0
-  - nbformat=5.0.4=py_0
+  - markupsafe=1.1.1=py37h8f50634_1
+  - mistune=0.8.4=py37h8f50634_1001
+  - nbconvert=5.6.1=py37hc8dfbb8_1
+  - nbformat=5.0.6=py_0
+  - nbresuse=0.3.3=py_0
   - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py37_0
+  - notebook=6.0.3=py37hc8dfbb8_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1d=h516909a_0
+  - openssl=1.1.1g=h516909a_0
+  - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.1.1=0
+  - pandoc=2.9.2.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
-  - pexpect=4.8.0=py37_0
-  - pickleshare=0.7.5=py37_1000
-  - pip=20.0.2=py37_0
-  - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.3=py_0
+  - parso=0.7.0=pyh9f0ad1d_0
+  - pexpect=4.8.0=py37hc8dfbb8_1
+  - pickleshare=0.7.5=py37hc8dfbb8_1001
+  - pip=20.1.1=py_1
+  - prometheus_client=0.8.0=pyh9f0ad1d_0
+  - prompt-toolkit=3.0.5=py_0
+  - psutil=5.7.0=py37h8f50634_1
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.19=py37_1
+  - pycparser=2.20=py_0
   - pycurl=7.43.0.5=py37h16ce93b_0
-  - pygments=2.5.2=py_0
+  - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.1.0=py37_0
-  - pyrsistent=0.15.7=py37h516909a_0
-  - pysocks=1.7.1=py37_0
-  - python=3.7.6=h357f687_2
+  - pyopenssl=19.1.0=py_1
+  - pyparsing=2.4.7=pyh9f0ad1d_0
+  - pyrsistent=0.16.0=py37h8f50634_0
+  - pysocks=1.7.1=py37hc8dfbb8_1
+  - python=3.7.6=cpython_h8356626_6
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
-  - pyzmq=18.1.1=py37h1768529_0
+  - python_abi=3.7=1_cp37m
+  - pyzmq=19.0.1=py37hac76be4_0
   - readline=8.0=hf8c457e_0
-  - requests=2.22.0=py37_1
-  - ruamel.yaml=0.16.6=py37h516909a_0
-  - ruamel.yaml.clib=0.2.0=py37h516909a_0
+  - requests=2.23.0=pyh8c360ce_2
+  - ruamel.yaml=0.16.6=py37h8f50634_1
+  - ruamel.yaml.clib=0.2.0=py37h8f50634_1
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py37_0
-  - six=1.14.0=py37_0
-  - sqlalchemy=1.3.13=py37h516909a_0
+  - setuptools=47.1.1=py37hc8dfbb8_0
+  - six=1.15.0=pyh9f0ad1d_0
+  - sqlalchemy=1.3.17=py37h8f50634_0
   - sqlite=3.30.1=hcee41ef_0
-  - terminado=0.8.3=py37_0
+  - terminado=0.8.3=py37hc8dfbb8_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py37h516909a_0
-  - traitlets=4.3.3=py37_0
-  - urllib3=1.25.7=py37_0
-  - wcwidth=0.1.8=py_0
+  - tornado=6.0.4=py37h8f50634_1
+  - traitlets=4.3.3=py37hc8dfbb8_1
+  - urllib3=1.25.9=py_0
+  - wcwidth=0.2.3=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py37_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py37_0
-  - xz=5.2.4=h14c3975_1001
+  - xz=5.2.5=h516909a_0
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-02 18:05:28 UTC
+# Frozen on 2020-06-03 20:30:54 UTC
 name: r2d
 channels:
   - conda-forge
@@ -52,7 +52,7 @@ dependencies:
   - tk=8.6.10=hed695b0_0
   - tornado=5.1.1=py27h14c3975_1000
   - traitlets=4.3.3=py27h8c360ce_1
-  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - wcwidth=0.1.9=pyh9f0ad1d_0
   - wheel=0.34.2=py_1
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-27 12:28:36 UTC
+# Frozen on 2020-06-02 18:05:28 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,47 +11,49 @@ dependencies:
   - backports=1.0=py_2
   - backports.shutil_get_terminal_size=1.0.0=py_3
   - backports_abc=0.5=py_1
-  - ca-certificates=2019.11.28=hecc5488_0
-  - certifi=2019.11.28=py27_0
-  - configparser=3.7.3=py27_1
-  - decorator=4.4.1=py_0
-  - entrypoints=0.3=py27_1000
-  - enum34=1.1.6=py27_1002
-  - futures=3.3.0=py27_0
+  - ca-certificates=2020.4.5.1=hecc5488_0
+  - certifi=2019.11.28=py27h8c360ce_1
+  - configparser=3.7.3=py27h8c360ce_2
+  - decorator=4.4.2=py_0
+  - entrypoints=0.3=py27h8c360ce_1001
+  - enum34=1.1.10=py27h8c360ce_1
+  - futures=3.3.0=py27h8c360ce_1
   - ipykernel=4.8.2=py27_0
   - ipython=5.8.0=py27_1
   - ipython_genutils=0.2.0=py_1
   - jupyter_client=5.3.4=py27_1
-  - jupyter_core=4.6.1=py27_0
-  - libffi=3.2.1=he1b5a44_1006
+  - jupyter_core=4.6.3=py27h8c360ce_1
+  - ld_impl_linux-64=2.34=h53a641e_4
+  - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - ncurses=6.1=hf484d3e_1002
-  - openssl=1.1.1d=h516909a_0
-  - pathlib2=2.3.5=py27_0
-  - pexpect=4.8.0=py27_0
-  - pickleshare=0.7.5=py27_1000
-  - pip=20.0.2=py27_0
+  - openssl=1.1.1g=h516909a_0
+  - pathlib2=2.3.5=py27h8c360ce_1
+  - pexpect=4.8.0=py27h8c360ce_1
+  - pickleshare=0.7.5=py27h8c360ce_1001
+  - pip=20.1.1=pyh9f0ad1d_0
   - prompt_toolkit=1.0.15=py_1
   - ptyprocess=0.6.0=py_1001
   - pygments=2.5.2=py_0
-  - python=2.7.15=h5a48372_1009
+  - python=2.7.15=h5a48372_1011_cpython
   - python-dateutil=2.8.1=py_0
-  - pyzmq=18.1.1=py27h1768529_0
+  - python_abi=2.7=1_cp27mu
+  - pyzmq=19.0.0=py27h76efe43_1
   - readline=8.0=hf8c457e_0
-  - scandir=1.10.0=py27h516909a_0
+  - scandir=1.10.0=py27hdf8410d_1
   - setuptools=44.0.0=py27_0
   - simplegeneric=0.8.1=py_1
   - singledispatch=3.4.0.3=py27_1000
-  - six=1.14.0=py27_0
+  - six=1.15.0=pyh9f0ad1d_0
   - sqlite=3.30.1=hcee41ef_0
   - tk=8.6.10=hed695b0_0
   - tornado=5.1.1=py27h14c3975_1000
-  - traitlets=4.3.3=py27_0
-  - wcwidth=0.1.8=py_0
-  - wheel=0.33.6=py27_0
+  - traitlets=4.3.3=py27h8c360ce_1
+  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - wheel=0.34.2=py_1
   - zeromq=4.3.2=he1b5a44_2
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d

--- a/repo2docker/buildpacks/conda/environment.py-2.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.yml
@@ -1,3 +1,4 @@
 dependencies:
 - python=2.7.*
 - ipykernel==4.8.2
+- wcwidth==0.1.9

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:21 UTC
+# Frozen on 2020-06-02 18:06:52 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,104 +8,109 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
-  - bleach=3.1.0=py_0
+  - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
-  - ca-certificates=2019.11.28=hecc5488_0
-  - certifi=2019.11.28=py36_0
+  - brotlipy=0.7.0=py36h8c4c3a4_1000
+  - ca-certificates=2020.4.5.1=hecc5488_0
+  - certifi=2020.4.5.1=py36h9f0ad1d_0
   - certipy=0.1.3=py_0
-  - cffi=1.13.2=py36h8022711_0
-  - chardet=3.0.4=py36_1003
-  - cryptography=2.8=py36h72c5cf5_1
-  - decorator=4.4.1=py_0
+  - cffi=1.14.0=py36hd463f26_0
+  - chardet=3.0.4=py36h9f0ad1d_1006
+  - cryptography=2.9.2=py36h45558ae_0
+  - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - entrypoints=0.3=py36_1000
-  - idna=2.8=py36_1000
-  - importlib_metadata=1.5.0=py36_0
-  - inflect=4.0.0=py36_1
-  - ipykernel=5.1.4=py36h5ca1d4c_0
-  - ipython=7.11.1=py36h5ca1d4c_0
+  - entrypoints=0.3=py36h9f0ad1d_1001
+  - idna=2.9=py_1
+  - importlib-metadata=1.6.0=py36h9f0ad1d_0
+  - importlib_metadata=1.6.0=0
+  - ipykernel=5.3.0=py36h95af2a2_0
+  - ipython=7.15.0=py36h9f0ad1d_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
-  - jedi=0.16.0=py36_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
-  - jsonschema=3.2.0=py36_0
-  - jupyter_client=5.3.4=py36_1
-  - jupyter_core=4.6.1=py36_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jedi=0.17.0=py36h9f0ad1d_0
+  - jinja2=2.11.2=pyh9f0ad1d_0
+  - json5=0.9.0=py_0
+  - jsonschema=3.2.0=py36h9f0ad1d_1
+  - jupyter_client=6.1.3=py_0
+  - jupyter_core=4.6.3=py36h9f0ad1d_1
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py36_2
   - jupyterhub-singleuser=1.1.0=py36_2
   - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.0.6=py_0
-  - krb5=1.16.4=h2fd8d38_0
-  - libcurl=7.65.3=hda55be3_0
-  - libedit=3.1.20170329=hf8c457e_1001
-  - libffi=3.2.1=he1b5a44_1006
+  - jupyterlab_server=1.1.5=py_0
+  - krb5=1.17.1=h2fd8d38_0
+  - ld_impl_linux-64=2.34=h53a641e_4
+  - libcurl=7.69.1=hf7181ac_0
+  - libedit=3.1.20191231=h46ee950_0
+  - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.8.2=h22169c7_2
+  - libssh2=1.9.0=hab1572f_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py36h516909a_0
-  - mistune=0.8.4=py36h516909a_1000
-  - more-itertools=8.2.0=py_0
-  - nbconvert=5.6.1=py36_0
-  - nbformat=5.0.4=py_0
+  - markupsafe=1.1.1=py36h8c4c3a4_1
+  - mistune=0.8.4=py36h8c4c3a4_1001
+  - nbconvert=5.6.1=py36h9f0ad1d_1
+  - nbformat=5.0.6=py_0
+  - nbresuse=0.3.3=py_0
   - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py36_0
+  - notebook=6.0.3=py36h9f0ad1d_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1d=h516909a_0
+  - openssl=1.1.1g=h516909a_0
+  - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.1.1=0
+  - pandoc=2.9.2.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
-  - pexpect=4.8.0=py36_0
-  - pickleshare=0.7.5=py36_1000
-  - pip=20.0.2=py36_0
-  - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.3=py_0
+  - parso=0.7.0=pyh9f0ad1d_0
+  - pexpect=4.8.0=py36h9f0ad1d_1
+  - pickleshare=0.7.5=py36h9f0ad1d_1001
+  - pip=20.1.1=py_1
+  - prometheus_client=0.8.0=pyh9f0ad1d_0
+  - prompt-toolkit=3.0.5=py_0
+  - psutil=5.7.0=py36h8c4c3a4_1
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.19=py36_1
+  - pycparser=2.20=py_0
   - pycurl=7.43.0.5=py36h16ce93b_0
-  - pygments=2.5.2=py_0
+  - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.1.0=py36_0
-  - pyrsistent=0.15.7=py36h516909a_0
-  - pysocks=1.7.1=py36_0
-  - python=3.6.7=h357f687_1006
+  - pyopenssl=19.1.0=py_1
+  - pyparsing=2.4.7=pyh9f0ad1d_0
+  - pyrsistent=0.16.0=py36h8c4c3a4_0
+  - pysocks=1.7.1=py36h9f0ad1d_1
+  - python=3.6.10=h8356626_1011_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
-  - pyzmq=18.1.1=py36h1768529_0
+  - python_abi=3.6=1_cp36m
+  - pyzmq=19.0.1=py36h9947dbf_0
   - readline=8.0=hf8c457e_0
-  - requests=2.22.0=py36_1
-  - ruamel.yaml=0.16.6=py36h516909a_0
-  - ruamel.yaml.clib=0.2.0=py36h516909a_0
+  - requests=2.23.0=pyh8c360ce_2
+  - ruamel.yaml=0.16.6=py36h8c4c3a4_1
+  - ruamel.yaml.clib=0.2.0=py36h8c4c3a4_1
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py36_0
-  - six=1.14.0=py36_0
-  - sqlalchemy=1.3.13=py36h516909a_0
+  - setuptools=47.1.1=py36h9f0ad1d_0
+  - six=1.15.0=pyh9f0ad1d_0
+  - sqlalchemy=1.3.17=py36h8c4c3a4_0
   - sqlite=3.30.1=hcee41ef_0
-  - terminado=0.8.3=py36_0
+  - terminado=0.8.3=py36h9f0ad1d_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py36h516909a_0
-  - traitlets=4.3.3=py36_0
-  - urllib3=1.25.7=py36_0
-  - wcwidth=0.1.8=py_0
+  - tornado=6.0.4=py36h8c4c3a4_1
+  - traitlets=4.3.3=py36h9f0ad1d_1
+  - urllib3=1.25.9=py_0
+  - wcwidth=0.2.3=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py36_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py36_0
-  - xz=5.2.4=h14c3975_1001
+  - xz=5.2.5=h516909a_0
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:54:21 UTC
+# Generated on 2020-06-02 18:06:52 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nbresuse==0.3.3
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:54:05 UTC
+# Frozen on 2020-06-02 18:09:38 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,105 +8,109 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
-  - bleach=3.1.0=py_0
+  - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
-  - ca-certificates=2019.11.28=hecc5488_0
-  - certifi=2019.11.28=py37_0
+  - brotlipy=0.7.0=py37h8f50634_1000
+  - ca-certificates=2020.4.5.1=hecc5488_0
+  - certifi=2020.4.5.1=py37hc8dfbb8_0
   - certipy=0.1.3=py_0
-  - cffi=1.13.2=py37h8022711_0
-  - chardet=3.0.4=py37_1003
-  - cryptography=2.8=py37h72c5cf5_1
-  - decorator=4.4.1=py_0
+  - cffi=1.14.0=py37hd463f26_0
+  - chardet=3.0.4=py37hc8dfbb8_1006
+  - cryptography=2.9.2=py37hb09aad4_0
+  - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - entrypoints=0.3=py37_1000
-  - idna=2.8=py37_1000
-  - importlib_metadata=1.5.0=py37_0
-  - inflect=4.0.0=py37_1
-  - ipykernel=5.1.4=py37h5ca1d4c_0
-  - ipython=7.11.1=py37h5ca1d4c_0
+  - entrypoints=0.3=py37hc8dfbb8_1001
+  - idna=2.9=py_1
+  - importlib-metadata=1.6.0=py37hc8dfbb8_0
+  - importlib_metadata=1.6.0=0
+  - ipykernel=5.3.0=py37h43977f1_0
+  - ipython=7.15.0=py37hc8dfbb8_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
-  - jedi=0.16.0=py37_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
-  - jsonschema=3.2.0=py37_0
-  - jupyter_client=5.3.4=py37_1
-  - jupyter_core=4.6.1=py37_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jedi=0.17.0=py37hc8dfbb8_0
+  - jinja2=2.11.2=pyh9f0ad1d_0
+  - json5=0.9.0=py_0
+  - jsonschema=3.2.0=py37hc8dfbb8_1
+  - jupyter_client=6.1.3=py_0
+  - jupyter_core=4.6.3=py37hc8dfbb8_1
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
   - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.0.6=py_0
-  - krb5=1.16.4=h2fd8d38_0
-  - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
-  - libedit=3.1.20170329=hf8c457e_1001
-  - libffi=3.2.1=he1b5a44_1006
+  - jupyterlab_server=1.1.5=py_0
+  - krb5=1.17.1=h2fd8d38_0
+  - ld_impl_linux-64=2.34=h53a641e_4
+  - libcurl=7.69.1=hf7181ac_0
+  - libedit=3.1.20191231=h46ee950_0
+  - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.8.2=h22169c7_2
+  - libssh2=1.9.0=hab1572f_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py37h516909a_0
-  - mistune=0.8.4=py37h516909a_1000
-  - more-itertools=8.2.0=py_0
-  - nbconvert=5.6.1=py37_0
-  - nbformat=5.0.4=py_0
+  - markupsafe=1.1.1=py37h8f50634_1
+  - mistune=0.8.4=py37h8f50634_1001
+  - nbconvert=5.6.1=py37hc8dfbb8_1
+  - nbformat=5.0.6=py_0
+  - nbresuse=0.3.3=py_0
   - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py37_0
+  - notebook=6.0.3=py37hc8dfbb8_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1d=h516909a_0
+  - openssl=1.1.1g=h516909a_0
+  - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.1.1=0
+  - pandoc=2.9.2.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
-  - pexpect=4.8.0=py37_0
-  - pickleshare=0.7.5=py37_1000
-  - pip=20.0.2=py37_0
-  - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.3=py_0
+  - parso=0.7.0=pyh9f0ad1d_0
+  - pexpect=4.8.0=py37hc8dfbb8_1
+  - pickleshare=0.7.5=py37hc8dfbb8_1001
+  - pip=20.1.1=py_1
+  - prometheus_client=0.8.0=pyh9f0ad1d_0
+  - prompt-toolkit=3.0.5=py_0
+  - psutil=5.7.0=py37h8f50634_1
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.19=py37_1
+  - pycparser=2.20=py_0
   - pycurl=7.43.0.5=py37h16ce93b_0
-  - pygments=2.5.2=py_0
+  - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.1.0=py37_0
-  - pyrsistent=0.15.7=py37h516909a_0
-  - pysocks=1.7.1=py37_0
-  - python=3.7.6=h357f687_2
+  - pyopenssl=19.1.0=py_1
+  - pyparsing=2.4.7=pyh9f0ad1d_0
+  - pyrsistent=0.16.0=py37h8f50634_0
+  - pysocks=1.7.1=py37hc8dfbb8_1
+  - python=3.7.6=cpython_h8356626_6
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
-  - pyzmq=18.1.1=py37h1768529_0
+  - python_abi=3.7=1_cp37m
+  - pyzmq=19.0.1=py37hac76be4_0
   - readline=8.0=hf8c457e_0
-  - requests=2.22.0=py37_1
-  - ruamel.yaml=0.16.6=py37h516909a_0
-  - ruamel.yaml.clib=0.2.0=py37h516909a_0
+  - requests=2.23.0=pyh8c360ce_2
+  - ruamel.yaml=0.16.6=py37h8f50634_1
+  - ruamel.yaml.clib=0.2.0=py37h8f50634_1
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py37_0
-  - six=1.14.0=py37_0
-  - sqlalchemy=1.3.13=py37h516909a_0
+  - setuptools=47.1.1=py37hc8dfbb8_0
+  - six=1.15.0=pyh9f0ad1d_0
+  - sqlalchemy=1.3.17=py37h8f50634_0
   - sqlite=3.30.1=hcee41ef_0
-  - terminado=0.8.3=py37_0
+  - terminado=0.8.3=py37hc8dfbb8_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py37h516909a_0
-  - traitlets=4.3.3=py37_0
-  - urllib3=1.25.7=py37_0
-  - wcwidth=0.1.8=py_0
+  - tornado=6.0.4=py37h8f50634_1
+  - traitlets=4.3.3=py37hc8dfbb8_1
+  - urllib3=1.25.9=py_0
+  - wcwidth=0.2.3=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py37_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py37_0
-  - xz=5.2.4=h14c3975_1001
+  - xz=5.2.5=h516909a_0
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:54:05 UTC
+# Generated on 2020-06-02 18:09:38 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nbresuse==0.3.3
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.8.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-01-30 10:53:33 UTC
+# Frozen on 2020-06-02 18:12:32 UTC
 name: r2d
 channels:
   - conda-forge
@@ -8,105 +8,109 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=0_gnu
-  - alembic=1.3.3=py_0
+  - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
   - backcall=0.1.0=py_0
-  - bleach=3.1.0=py_0
+  - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
-  - ca-certificates=2019.11.28=hecc5488_0
-  - certifi=2019.11.28=py38_0
+  - brotlipy=0.7.0=py38h1e0a361_1000
+  - ca-certificates=2020.4.5.1=hecc5488_0
+  - certifi=2020.4.5.1=py38h32f6830_0
   - certipy=0.1.3=py_0
-  - cffi=1.13.2=py38h8022711_0
-  - chardet=3.0.4=py38_1003
-  - cryptography=2.8=py38h72c5cf5_1
-  - decorator=4.4.1=py_0
+  - cffi=1.14.0=py38hd463f26_0
+  - chardet=3.0.4=py38h32f6830_1006
+  - cryptography=2.9.2=py38h766eaa4_0
+  - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - entrypoints=0.3=py38_1000
-  - idna=2.8=py38_1000
-  - importlib_metadata=1.5.0=py38_0
-  - inflect=4.0.0=py38_1
-  - ipykernel=5.1.4=py38h5ca1d4c_0
-  - ipython=7.11.1=py38h5ca1d4c_0
+  - entrypoints=0.3=py38h32f6830_1001
+  - idna=2.9=py_1
+  - importlib-metadata=1.6.0=py38h32f6830_0
+  - importlib_metadata=1.6.0=0
+  - ipykernel=5.3.0=py38h23f93f0_0
+  - ipython=7.15.0=py38h32f6830_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jaraco.itertools=5.0.0=py_0
-  - jedi=0.16.0=py38_0
-  - jinja2=2.11.0=py_0
-  - json5=0.8.5=py_0
-  - jsonschema=3.2.0=py38_0
-  - jupyter_client=5.3.4=py38_1
-  - jupyter_core=4.6.1=py38_0
-  - jupyter_telemetry=0.0.4=py_0
+  - jedi=0.17.0=py38h32f6830_0
+  - jinja2=2.11.2=pyh9f0ad1d_0
+  - json5=0.9.0=py_0
+  - jsonschema=3.2.0=py38h32f6830_1
+  - jupyter_client=6.1.3=py_0
+  - jupyter_core=4.6.3=py38h32f6830_1
+  - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py38_2
   - jupyterhub-singleuser=1.1.0=py38_2
   - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.0.6=py_0
-  - krb5=1.16.4=h2fd8d38_0
-  - ld_impl_linux-64=2.33.1=h53a641e_8
-  - libcurl=7.65.3=hda55be3_0
-  - libedit=3.1.20170329=hf8c457e_1001
-  - libffi=3.2.1=he1b5a44_1006
+  - jupyterlab_server=1.1.5=py_0
+  - krb5=1.17.1=h2fd8d38_0
+  - ld_impl_linux-64=2.34=h53a641e_4
+  - libcurl=7.69.1=hf7181ac_0
+  - libedit=3.1.20191231=h46ee950_0
+  - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.8.2=h22169c7_2
+  - libssh2=1.9.0=hab1572f_2
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py38h516909a_0
-  - mistune=0.8.4=py38h516909a_1000
-  - more-itertools=8.2.0=py_0
-  - nbconvert=5.6.1=py38_0
-  - nbformat=5.0.4=py_0
+  - markupsafe=1.1.1=py38h1e0a361_1
+  - mistune=0.8.4=py38h1e0a361_1001
+  - nbconvert=5.6.1=py38h32f6830_1
+  - nbformat=5.0.6=py_0
+  - nbresuse=0.3.3=py_0
   - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py38_0
+  - notebook=6.0.3=py38h32f6830_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1d=h516909a_0
+  - openssl=1.1.1g=h516909a_0
+  - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.1.1=0
+  - pandoc=2.9.2.1=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.6.0=py_0
-  - pexpect=4.8.0=py38_0
-  - pickleshare=0.7.5=py38_1000
-  - pip=20.0.2=py38_0
-  - prometheus_client=0.7.1=py_0
-  - prompt_toolkit=3.0.3=py_0
+  - parso=0.7.0=pyh9f0ad1d_0
+  - pexpect=4.8.0=py38h32f6830_1
+  - pickleshare=0.7.5=py38h32f6830_1001
+  - pip=20.1.1=py_1
+  - prometheus_client=0.8.0=pyh9f0ad1d_0
+  - prompt-toolkit=3.0.5=py_0
+  - psutil=5.7.0=py38h1e0a361_1
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.19=py38_1
+  - pycparser=2.20=py_0
   - pycurl=7.43.0.5=py38h16ce93b_0
-  - pygments=2.5.2=py_0
+  - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
-  - pyopenssl=19.1.0=py38_0
-  - pyrsistent=0.15.7=py38h516909a_0
-  - pysocks=1.7.1=py38_0
-  - python=3.8.1=h357f687_2
+  - pyopenssl=19.1.0=py_1
+  - pyparsing=2.4.7=pyh9f0ad1d_0
+  - pyrsistent=0.16.0=py38h1e0a361_0
+  - pysocks=1.7.1=py38h32f6830_1
+  - python=3.8.3=cpython_he5300dc_0
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
-  - pyzmq=18.1.1=py38h1768529_0
+  - python_abi=3.8=1_cp38
+  - pyzmq=19.0.1=py38ha71036d_0
   - readline=8.0=hf8c457e_0
-  - requests=2.22.0=py38_1
-  - ruamel.yaml=0.16.6=py38h516909a_0
-  - ruamel.yaml.clib=0.2.0=py38h516909a_0
+  - requests=2.23.0=pyh8c360ce_2
+  - ruamel.yaml=0.16.6=py38h1e0a361_1
+  - ruamel.yaml.clib=0.2.0=py38h1e0a361_1
   - send2trash=1.5.0=py_0
-  - setuptools=45.1.0=py38_0
-  - six=1.14.0=py38_0
-  - sqlalchemy=1.3.13=py38h516909a_0
+  - setuptools=47.1.1=py38h32f6830_0
+  - six=1.15.0=pyh9f0ad1d_0
+  - sqlalchemy=1.3.17=py38h1e0a361_0
   - sqlite=3.30.1=hcee41ef_0
-  - terminado=0.8.3=py38_0
+  - terminado=0.8.3=py38h32f6830_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
-  - tornado=6.0.3=py38h516909a_0
-  - traitlets=4.3.3=py38_0
-  - urllib3=1.25.7=py38_0
-  - wcwidth=0.1.8=py_0
+  - tornado=6.0.4=py38h1e0a361_1
+  - traitlets=4.3.3=py38h32f6830_1
+  - urllib3=1.25.9=py_0
+  - wcwidth=0.2.3=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
-  - wheel=0.34.1=py38_0
+  - wheel=0.34.2=py_1
   - widgetsnbextension=3.5.1=py38_0
-  - xz=5.2.4=h14c3975_1001
+  - xz=5.2.5=h516909a_0
   - zeromq=4.3.2=he1b5a44_2
-  - zipp=2.1.0=py_0
+  - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006
 prefix: /opt/conda/envs/r2d
 

--- a/repo2docker/buildpacks/conda/environment.py-3.8.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.yml
@@ -1,10 +1,11 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-01-30 10:53:33 UTC
+# Generated on 2020-06-02 18:12:32 UTC
 dependencies:
 - python=3.8.*
 - ipywidgets==7.5.1
 - jupyterlab==1.2.6
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
+- nbresuse==0.3.3
 - notebook==6.0.3
 - nteract_on_jupyter==2.1.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -4,5 +4,6 @@ dependencies:
   - jupyterlab==1.2.6
   - jupyterhub-singleuser==1.1.0
   - nbconvert==5.6.1
+  - nbresuse==0.3.3
   - notebook==6.0.3
   - nteract_on_jupyter==2.1.3


### PR DESCRIPTION
Adds `nbresuse==0.3.3`, followed by [running `freeze.py`](https://github.com/jupyter/repo2docker/blob/master/docs/source/contributing/tasks.md#update-and-freeze-buildpack-dependencies)

JupyterLab automatically displays the metrics provided by nbresuse, it doesn't need a separate extension. Note that as mentioned in https://github.com/jupyterhub/binderhub/issues/1097#issuecomment-626628598 there are alternative JupyterLab front-ends for nbresuse, for instance https://github.com/jtpio/jupyterlab-system-monitor

Closes https://github.com/jupyterhub/binderhub/issues/1097

Screenshots from testing locally with `docker run -e MEM_LIMIT=200000000 ...`

Notebook:
![image](https://user-images.githubusercontent.com/1644105/83563753-7ab70d80-a513-11ea-84e5-307fab0c9159.png)

Lab:
![image](https://user-images.githubusercontent.com/1644105/83563798-8c98b080-a513-11ea-9d3f-200c4d1463eb.png)

