### PR TITLE
[MRG] Make the memory limit test simpler

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,9 +1,9 @@
 # Note that there are a dev-requirements.txt and a docs/doc-requirements.txt
-# files in this project, if you are updating this Pipfile make sure to 
+# files in this project, if you are updating this Pipfile make sure to
 # update these accordingly
 
 [dev-packages]
-pytest=">=3.6"
+pytest=">=4.6"
 wheel="*"
 pytest-cov="*"
 PyYAML = "*"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # Note that there is also a Pipfile for this project if you are updating this
 # file do not forget to update the Pipfile accordingly
 pyyaml
-pytest>=3.6
+pytest>=4.6
 wheel
 pytest-cov
 pre-commit


### PR DESCRIPTION
Instead of checking that a build which allocates too much memory does
fail, we now only check that we pass the correct arguments to the Docker
API client. It seems reasonable to rely on the docker client working and
doing the right thing. This solves a problem where our CI is flakey
because the kernel of the VM the tests run on doesn't support this.

Hopefully this will make our CI faster and less flakey.