### PR TITLE
Bump nix version to 2.3

### DIFF
--- a/repo2docker/buildpacks/nix/install-nix.bash
+++ b/repo2docker/buildpacks/nix/install-nix.bash
@@ -2,13 +2,13 @@
 # This downloads and installs a pinned version of nix
 set -ex
 
-NIX_VERSION="2.1.1"
-NIX_SHA256="ad10b4da69035a585fe89d7330037c4a5d867a372bb0e52a1542ab95aec67999"
+NIX_VERSION="2.3"
+NIX_SHA256="e43f6947d1f302b6193302889e7800f3e3dd4a650b6f929c668c894884a02701"
 
 # Do all our operations in /tmp, since we can't rely on current directory being writeable yet.
 cd /tmp
-wget --quiet https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.bz2
-echo "$NIX_SHA256  nix-2.1.1-x86_64-linux.tar.bz2" | sha256sum -c
-tar xjf nix-*-x86_64-linux.tar.bz2
+wget --quiet https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz
+echo "$NIX_SHA256  nix-$NIX_VERSION-x86_64-linux.tar.xz" | sha256sum -c
+tar xJf nix-*-x86_64-linux.tar.xz
 sh nix-*-x86_64-linux/install
 rm -r nix-*-x86_64-linux*


### PR DESCRIPTION
- This addresses issue #911
- This is untested, but there is no documented reason why repo2docker
  should stick with the previously pinned version 2.1.1
- Upstream has switched from bz2 to xz, so `tar` now takes the `-J` flag
  instead of `-j`

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
