### PR TITLE
Update JupyterLab to 2.2.0

### DIFF
--- a/repo2docker/buildpacks/conda/environment.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-02 18:09:38 UTC
+# Frozen on 2020-07-25 17:16:14 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,104 +11,104 @@ dependencies:
   - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
-  - backcall=0.1.0=py_0
+  - backcall=0.2.0=pyh9f0ad1d_0
   - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
   - brotlipy=0.7.0=py37h8f50634_1000
-  - ca-certificates=2020.4.5.1=hecc5488_0
-  - certifi=2020.4.5.1=py37hc8dfbb8_0
+  - ca-certificates=2020.6.20=hecda079_0
+  - certifi=2020.6.20=py37hc8dfbb8_0
   - certipy=0.1.3=py_0
   - cffi=1.14.0=py37hd463f26_0
   - chardet=3.0.4=py37hc8dfbb8_1006
-  - cryptography=2.9.2=py37hb09aad4_0
+  - cryptography=3.0=py37hb09aad4_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37hc8dfbb8_1001
-  - idna=2.9=py_1
-  - importlib-metadata=1.6.0=py37hc8dfbb8_0
-  - importlib_metadata=1.6.0=0
-  - ipykernel=5.3.0=py37h43977f1_0
-  - ipython=7.15.0=py37hc8dfbb8_0
+  - idna=2.10=pyh9f0ad1d_0
+  - importlib-metadata=1.7.0=py37hc8dfbb8_0
+  - importlib_metadata=1.7.0=0
+  - ipykernel=5.3.4=py37h43977f1_0
+  - ipython=7.16.1=py37h43977f1_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jedi=0.17.0=py37hc8dfbb8_0
+  - jedi=0.17.2=py37hc8dfbb8_0
   - jinja2=2.11.2=pyh9f0ad1d_0
-  - json5=0.9.0=py_0
+  - json5=0.9.4=pyh9f0ad1d_0
   - jsonschema=3.2.0=py37hc8dfbb8_1
-  - jupyter_client=6.1.3=py_0
+  - jupyter_client=6.1.6=py_0
   - jupyter_core=4.6.3=py37hc8dfbb8_1
   - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
-  - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.1.5=py_0
-  - krb5=1.17.1=h2fd8d38_0
-  - ld_impl_linux-64=2.34=h53a641e_4
-  - libcurl=7.69.1=hf7181ac_0
-  - libedit=3.1.20191231=h46ee950_0
+  - jupyterlab=2.2.0=py_0
+  - jupyterlab_server=1.2.0=py_0
+  - krb5=1.17.1=hfafb76e_1
+  - ld_impl_linux-64=2.34=h53a641e_7
+  - libcurl=7.71.1=hcdd3856_3
+  - libedit=3.1.20191231=h46ee950_1
   - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.9.0=hab1572f_2
+  - libssh2=1.9.0=hab1572f_4
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h8f50634_1
   - mistune=0.8.4=py37h8f50634_1001
   - nbconvert=5.6.1=py37hc8dfbb8_1
-  - nbformat=5.0.6=py_0
+  - nbformat=5.0.7=py_0
   - nbresuse=0.3.3=py_0
-  - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py37hc8dfbb8_0
+  - ncurses=6.2=he1b5a44_1
+  - notebook=6.0.3=py37hc8dfbb8_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1g=h516909a_0
   - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.2.1=0
+  - pandoc=2.10.1=h516909a_0
   - pandocfilters=1.4.2=py_1
-  - parso=0.7.0=pyh9f0ad1d_0
+  - parso=0.7.1=pyh9f0ad1d_0
   - pexpect=4.8.0=py37hc8dfbb8_1
   - pickleshare=0.7.5=py37hc8dfbb8_1001
   - pip=20.1.1=py_1
   - prometheus_client=0.8.0=pyh9f0ad1d_0
-  - prompt-toolkit=3.0.5=py_0
-  - psutil=5.7.0=py37h8f50634_1
+  - prompt-toolkit=3.0.5=py_1
+  - psutil=5.7.2=py37h8f50634_0
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.20=py_0
-  - pycurl=7.43.0.5=py37h16ce93b_0
+  - pycparser=2.20=pyh9f0ad1d_2
+  - pycurl=7.43.0.5=py37hce7685b_2
   - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
   - pyrsistent=0.16.0=py37h8f50634_0
   - pysocks=1.7.1=py37hc8dfbb8_1
-  - python=3.7.6=cpython_h8356626_6
+  - python=3.7.8=h6f2ec95_0_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
   - python_abi=3.7=1_cp37m
   - pyzmq=19.0.1=py37hac76be4_0
-  - readline=8.0=hf8c457e_0
-  - requests=2.23.0=pyh8c360ce_2
+  - readline=8.0=he28a2e2_2
+  - requests=2.24.0=pyh9f0ad1d_0
   - ruamel.yaml=0.16.6=py37h8f50634_1
   - ruamel.yaml.clib=0.2.0=py37h8f50634_1
   - send2trash=1.5.0=py_0
-  - setuptools=47.1.1=py37hc8dfbb8_0
+  - setuptools=49.2.0=py37hc8dfbb8_0
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlalchemy=1.3.17=py37h8f50634_0
-  - sqlite=3.30.1=hcee41ef_0
+  - sqlalchemy=1.3.18=py37h8f50634_0
+  - sqlite=3.32.3=hcee41ef_1
   - terminado=0.8.3=py37hc8dfbb8_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
   - tornado=6.0.4=py37h8f50634_1
   - traitlets=4.3.3=py37hc8dfbb8_1
-  - urllib3=1.25.9=py_0
-  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - urllib3=1.25.10=py_0
+  - wcwidth=0.2.5=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
   - wheel=0.34.2=py_1
-  - widgetsnbextension=3.5.1=py37_0
-  - xz=5.2.5=h516909a_0
+  - widgetsnbextension=3.5.1=py37hc8dfbb8_1
+  - xz=5.2.5=h516909a_1
   - zeromq=4.3.2=he1b5a44_2
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-2.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-2.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-03 20:30:54 UTC
+# Frozen on 2020-07-25 17:13:39 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,7 +11,7 @@ dependencies:
   - backports=1.0=py_2
   - backports.shutil_get_terminal_size=1.0.0=py_3
   - backports_abc=0.5=py_1
-  - ca-certificates=2020.4.5.1=hecc5488_0
+  - ca-certificates=2020.6.20=hecda079_0
   - certifi=2019.11.28=py27h8c360ce_1
   - configparser=3.7.3=py27h8c360ce_2
   - decorator=4.4.2=py_0
@@ -23,13 +23,13 @@ dependencies:
   - ipython_genutils=0.2.0=py_1
   - jupyter_client=5.3.4=py27_1
   - jupyter_core=4.6.3=py27h8c360ce_1
-  - ld_impl_linux-64=2.34=h53a641e_4
+  - ld_impl_linux-64=2.34=h53a641e_7
   - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
   - libstdcxx-ng=9.2.0=hdf63c60_2
-  - ncurses=6.1=hf484d3e_1002
+  - ncurses=6.2=he1b5a44_1
   - openssl=1.1.1g=h516909a_0
   - pathlib2=2.3.5=py27h8c360ce_1
   - pexpect=4.8.0=py27h8c360ce_1
@@ -42,13 +42,13 @@ dependencies:
   - python-dateutil=2.8.1=py_0
   - python_abi=2.7=1_cp27mu
   - pyzmq=19.0.0=py27h76efe43_1
-  - readline=8.0=hf8c457e_0
+  - readline=8.0=he28a2e2_2
   - scandir=1.10.0=py27hdf8410d_1
   - setuptools=44.0.0=py27_0
   - simplegeneric=0.8.1=py_1
   - singledispatch=3.4.0.3=py27_1000
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlite=3.30.1=hcee41ef_0
+  - sqlite=3.32.3=hcee41ef_1
   - tk=8.6.10=hed695b0_0
   - tornado=5.1.1=py27h14c3975_1000
   - traitlets=4.3.3=py27h8c360ce_1

--- a/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.6.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-02 18:06:52 UTC
+# Frozen on 2020-07-25 17:14:29 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,104 +11,104 @@ dependencies:
   - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
-  - backcall=0.1.0=py_0
+  - backcall=0.2.0=pyh9f0ad1d_0
   - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
   - brotlipy=0.7.0=py36h8c4c3a4_1000
-  - ca-certificates=2020.4.5.1=hecc5488_0
-  - certifi=2020.4.5.1=py36h9f0ad1d_0
+  - ca-certificates=2020.6.20=hecda079_0
+  - certifi=2020.6.20=py36h9f0ad1d_0
   - certipy=0.1.3=py_0
   - cffi=1.14.0=py36hd463f26_0
   - chardet=3.0.4=py36h9f0ad1d_1006
-  - cryptography=2.9.2=py36h45558ae_0
+  - cryptography=3.0=py36h45558ae_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py36h9f0ad1d_1001
-  - idna=2.9=py_1
-  - importlib-metadata=1.6.0=py36h9f0ad1d_0
-  - importlib_metadata=1.6.0=0
-  - ipykernel=5.3.0=py36h95af2a2_0
-  - ipython=7.15.0=py36h9f0ad1d_0
+  - idna=2.10=pyh9f0ad1d_0
+  - importlib-metadata=1.7.0=py36h9f0ad1d_0
+  - importlib_metadata=1.7.0=0
+  - ipykernel=5.3.4=py36h95af2a2_0
+  - ipython=7.16.1=py36h95af2a2_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jedi=0.17.0=py36h9f0ad1d_0
+  - jedi=0.17.2=py36h9f0ad1d_0
   - jinja2=2.11.2=pyh9f0ad1d_0
-  - json5=0.9.0=py_0
+  - json5=0.9.4=pyh9f0ad1d_0
   - jsonschema=3.2.0=py36h9f0ad1d_1
-  - jupyter_client=6.1.3=py_0
+  - jupyter_client=6.1.6=py_0
   - jupyter_core=4.6.3=py36h9f0ad1d_1
   - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py36_2
   - jupyterhub-singleuser=1.1.0=py36_2
-  - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.1.5=py_0
-  - krb5=1.17.1=h2fd8d38_0
-  - ld_impl_linux-64=2.34=h53a641e_4
-  - libcurl=7.69.1=hf7181ac_0
-  - libedit=3.1.20191231=h46ee950_0
+  - jupyterlab=2.2.0=py_0
+  - jupyterlab_server=1.2.0=py_0
+  - krb5=1.17.1=hfafb76e_1
+  - ld_impl_linux-64=2.34=h53a641e_7
+  - libcurl=7.71.1=hcdd3856_3
+  - libedit=3.1.20191231=h46ee950_1
   - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.9.0=hab1572f_2
+  - libssh2=1.9.0=hab1572f_4
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py36h8c4c3a4_1
   - mistune=0.8.4=py36h8c4c3a4_1001
   - nbconvert=5.6.1=py36h9f0ad1d_1
-  - nbformat=5.0.6=py_0
+  - nbformat=5.0.7=py_0
   - nbresuse=0.3.3=py_0
-  - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py36h9f0ad1d_0
+  - ncurses=6.2=he1b5a44_1
+  - notebook=6.0.3=py36h9f0ad1d_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1g=h516909a_0
   - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.2.1=0
+  - pandoc=2.10.1=h516909a_0
   - pandocfilters=1.4.2=py_1
-  - parso=0.7.0=pyh9f0ad1d_0
+  - parso=0.7.1=pyh9f0ad1d_0
   - pexpect=4.8.0=py36h9f0ad1d_1
   - pickleshare=0.7.5=py36h9f0ad1d_1001
   - pip=20.1.1=py_1
   - prometheus_client=0.8.0=pyh9f0ad1d_0
-  - prompt-toolkit=3.0.5=py_0
-  - psutil=5.7.0=py36h8c4c3a4_1
+  - prompt-toolkit=3.0.5=py_1
+  - psutil=5.7.2=py36h8c4c3a4_0
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.20=py_0
-  - pycurl=7.43.0.5=py36h16ce93b_0
+  - pycparser=2.20=pyh9f0ad1d_2
+  - pycurl=7.43.0.5=py36h2e6c563_2
   - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
   - pyrsistent=0.16.0=py36h8c4c3a4_0
   - pysocks=1.7.1=py36h9f0ad1d_1
-  - python=3.6.10=h8356626_1011_cpython
+  - python=3.6.11=h425cb1d_0_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
   - python_abi=3.6=1_cp36m
   - pyzmq=19.0.1=py36h9947dbf_0
-  - readline=8.0=hf8c457e_0
-  - requests=2.23.0=pyh8c360ce_2
+  - readline=8.0=he28a2e2_2
+  - requests=2.24.0=pyh9f0ad1d_0
   - ruamel.yaml=0.16.6=py36h8c4c3a4_1
   - ruamel.yaml.clib=0.2.0=py36h8c4c3a4_1
   - send2trash=1.5.0=py_0
-  - setuptools=47.1.1=py36h9f0ad1d_0
+  - setuptools=49.2.0=py36h9f0ad1d_0
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlalchemy=1.3.17=py36h8c4c3a4_0
-  - sqlite=3.30.1=hcee41ef_0
+  - sqlalchemy=1.3.18=py36h8c4c3a4_0
+  - sqlite=3.32.3=hcee41ef_1
   - terminado=0.8.3=py36h9f0ad1d_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
   - tornado=6.0.4=py36h8c4c3a4_1
   - traitlets=4.3.3=py36h9f0ad1d_1
-  - urllib3=1.25.9=py_0
-  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - urllib3=1.25.10=py_0
+  - wcwidth=0.2.5=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
   - wheel=0.34.2=py_1
-  - widgetsnbextension=3.5.1=py36_0
-  - xz=5.2.5=h516909a_0
+  - widgetsnbextension=3.5.1=py36h9f0ad1d_1
+  - xz=5.2.5=h516909a_1
   - zeromq=4.3.2=he1b5a44_2
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-3.6.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.6.yml
@@ -1,9 +1,9 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-06-02 18:06:52 UTC
+# Generated on 2020-07-25 17:14:29 UTC
 dependencies:
 - python=3.6.*
 - ipywidgets==7.5.1
-- jupyterlab==1.2.6
+- jupyterlab==2.2.0
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
 - nbresuse==0.3.3

--- a/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-02 18:09:38 UTC
+# Frozen on 2020-07-25 17:16:14 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,104 +11,104 @@ dependencies:
   - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
-  - backcall=0.1.0=py_0
+  - backcall=0.2.0=pyh9f0ad1d_0
   - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
   - brotlipy=0.7.0=py37h8f50634_1000
-  - ca-certificates=2020.4.5.1=hecc5488_0
-  - certifi=2020.4.5.1=py37hc8dfbb8_0
+  - ca-certificates=2020.6.20=hecda079_0
+  - certifi=2020.6.20=py37hc8dfbb8_0
   - certipy=0.1.3=py_0
   - cffi=1.14.0=py37hd463f26_0
   - chardet=3.0.4=py37hc8dfbb8_1006
-  - cryptography=2.9.2=py37hb09aad4_0
+  - cryptography=3.0=py37hb09aad4_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py37hc8dfbb8_1001
-  - idna=2.9=py_1
-  - importlib-metadata=1.6.0=py37hc8dfbb8_0
-  - importlib_metadata=1.6.0=0
-  - ipykernel=5.3.0=py37h43977f1_0
-  - ipython=7.15.0=py37hc8dfbb8_0
+  - idna=2.10=pyh9f0ad1d_0
+  - importlib-metadata=1.7.0=py37hc8dfbb8_0
+  - importlib_metadata=1.7.0=0
+  - ipykernel=5.3.4=py37h43977f1_0
+  - ipython=7.16.1=py37h43977f1_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jedi=0.17.0=py37hc8dfbb8_0
+  - jedi=0.17.2=py37hc8dfbb8_0
   - jinja2=2.11.2=pyh9f0ad1d_0
-  - json5=0.9.0=py_0
+  - json5=0.9.4=pyh9f0ad1d_0
   - jsonschema=3.2.0=py37hc8dfbb8_1
-  - jupyter_client=6.1.3=py_0
+  - jupyter_client=6.1.6=py_0
   - jupyter_core=4.6.3=py37hc8dfbb8_1
   - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py37_2
   - jupyterhub-singleuser=1.1.0=py37_2
-  - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.1.5=py_0
-  - krb5=1.17.1=h2fd8d38_0
-  - ld_impl_linux-64=2.34=h53a641e_4
-  - libcurl=7.69.1=hf7181ac_0
-  - libedit=3.1.20191231=h46ee950_0
+  - jupyterlab=2.2.0=py_0
+  - jupyterlab_server=1.2.0=py_0
+  - krb5=1.17.1=hfafb76e_1
+  - ld_impl_linux-64=2.34=h53a641e_7
+  - libcurl=7.71.1=hcdd3856_3
+  - libedit=3.1.20191231=h46ee950_1
   - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.9.0=hab1572f_2
+  - libssh2=1.9.0=hab1572f_4
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py37h8f50634_1
   - mistune=0.8.4=py37h8f50634_1001
   - nbconvert=5.6.1=py37hc8dfbb8_1
-  - nbformat=5.0.6=py_0
+  - nbformat=5.0.7=py_0
   - nbresuse=0.3.3=py_0
-  - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py37hc8dfbb8_0
+  - ncurses=6.2=he1b5a44_1
+  - notebook=6.0.3=py37hc8dfbb8_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1g=h516909a_0
   - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.2.1=0
+  - pandoc=2.10.1=h516909a_0
   - pandocfilters=1.4.2=py_1
-  - parso=0.7.0=pyh9f0ad1d_0
+  - parso=0.7.1=pyh9f0ad1d_0
   - pexpect=4.8.0=py37hc8dfbb8_1
   - pickleshare=0.7.5=py37hc8dfbb8_1001
   - pip=20.1.1=py_1
   - prometheus_client=0.8.0=pyh9f0ad1d_0
-  - prompt-toolkit=3.0.5=py_0
-  - psutil=5.7.0=py37h8f50634_1
+  - prompt-toolkit=3.0.5=py_1
+  - psutil=5.7.2=py37h8f50634_0
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.20=py_0
-  - pycurl=7.43.0.5=py37h16ce93b_0
+  - pycparser=2.20=pyh9f0ad1d_2
+  - pycurl=7.43.0.5=py37hce7685b_2
   - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
   - pyrsistent=0.16.0=py37h8f50634_0
   - pysocks=1.7.1=py37hc8dfbb8_1
-  - python=3.7.6=cpython_h8356626_6
+  - python=3.7.8=h6f2ec95_0_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
   - python_abi=3.7=1_cp37m
   - pyzmq=19.0.1=py37hac76be4_0
-  - readline=8.0=hf8c457e_0
-  - requests=2.23.0=pyh8c360ce_2
+  - readline=8.0=he28a2e2_2
+  - requests=2.24.0=pyh9f0ad1d_0
   - ruamel.yaml=0.16.6=py37h8f50634_1
   - ruamel.yaml.clib=0.2.0=py37h8f50634_1
   - send2trash=1.5.0=py_0
-  - setuptools=47.1.1=py37hc8dfbb8_0
+  - setuptools=49.2.0=py37hc8dfbb8_0
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlalchemy=1.3.17=py37h8f50634_0
-  - sqlite=3.30.1=hcee41ef_0
+  - sqlalchemy=1.3.18=py37h8f50634_0
+  - sqlite=3.32.3=hcee41ef_1
   - terminado=0.8.3=py37hc8dfbb8_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
   - tornado=6.0.4=py37h8f50634_1
   - traitlets=4.3.3=py37hc8dfbb8_1
-  - urllib3=1.25.9=py_0
-  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - urllib3=1.25.10=py_0
+  - wcwidth=0.2.5=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
   - wheel=0.34.2=py_1
-  - widgetsnbextension=3.5.1=py37_0
-  - xz=5.2.5=h516909a_0
+  - widgetsnbextension=3.5.1=py37hc8dfbb8_1
+  - xz=5.2.5=h516909a_1
   - zeromq=4.3.2=he1b5a44_2
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-3.7.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.7.yml
@@ -1,9 +1,9 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-06-02 18:09:38 UTC
+# Generated on 2020-07-25 17:16:14 UTC
 dependencies:
 - python=3.7.*
 - ipywidgets==7.5.1
-- jupyterlab==1.2.6
+- jupyterlab==2.2.0
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
 - nbresuse==0.3.3

--- a/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.8.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-06-02 18:12:32 UTC
+# Frozen on 2020-07-25 17:17:57 UTC
 name: r2d
 channels:
   - conda-forge
@@ -11,104 +11,104 @@ dependencies:
   - alembic=1.4.2=pyh9f0ad1d_0
   - async_generator=1.10=py_0
   - attrs=19.3.0=py_0
-  - backcall=0.1.0=py_0
+  - backcall=0.2.0=pyh9f0ad1d_0
   - bleach=3.1.5=pyh9f0ad1d_0
   - blinker=1.4=py_1
   - brotlipy=0.7.0=py38h1e0a361_1000
-  - ca-certificates=2020.4.5.1=hecc5488_0
-  - certifi=2020.4.5.1=py38h32f6830_0
+  - ca-certificates=2020.6.20=hecda079_0
+  - certifi=2020.6.20=py38h32f6830_0
   - certipy=0.1.3=py_0
   - cffi=1.14.0=py38hd463f26_0
   - chardet=3.0.4=py38h32f6830_1006
-  - cryptography=2.9.2=py38h766eaa4_0
+  - cryptography=3.0=py38h766eaa4_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
   - entrypoints=0.3=py38h32f6830_1001
-  - idna=2.9=py_1
-  - importlib-metadata=1.6.0=py38h32f6830_0
-  - importlib_metadata=1.6.0=0
-  - ipykernel=5.3.0=py38h23f93f0_0
-  - ipython=7.15.0=py38h32f6830_0
+  - idna=2.10=pyh9f0ad1d_0
+  - importlib-metadata=1.7.0=py38h32f6830_0
+  - importlib_metadata=1.7.0=0
+  - ipykernel=5.3.4=py38h23f93f0_0
+  - ipython=7.16.1=py38h23f93f0_0
   - ipython_genutils=0.2.0=py_1
   - ipywidgets=7.5.1=py_0
-  - jedi=0.17.0=py38h32f6830_0
+  - jedi=0.17.2=py38h32f6830_0
   - jinja2=2.11.2=pyh9f0ad1d_0
-  - json5=0.9.0=py_0
+  - json5=0.9.4=pyh9f0ad1d_0
   - jsonschema=3.2.0=py38h32f6830_1
-  - jupyter_client=6.1.3=py_0
+  - jupyter_client=6.1.6=py_0
   - jupyter_core=4.6.3=py38h32f6830_1
   - jupyter_telemetry=0.0.5=py_0
   - jupyterhub-base=1.1.0=py38_2
   - jupyterhub-singleuser=1.1.0=py38_2
-  - jupyterlab=1.2.6=py_0
-  - jupyterlab_server=1.1.5=py_0
-  - krb5=1.17.1=h2fd8d38_0
-  - ld_impl_linux-64=2.34=h53a641e_4
-  - libcurl=7.69.1=hf7181ac_0
-  - libedit=3.1.20191231=h46ee950_0
+  - jupyterlab=2.2.0=py_0
+  - jupyterlab_server=1.2.0=py_0
+  - krb5=1.17.1=hfafb76e_1
+  - ld_impl_linux-64=2.34=h53a641e_7
+  - libcurl=7.71.1=hcdd3856_3
+  - libedit=3.1.20191231=h46ee950_1
   - libffi=3.2.1=he1b5a44_1007
   - libgcc-ng=9.2.0=h24d8f2e_2
   - libgomp=9.2.0=h24d8f2e_2
   - libsodium=1.0.17=h516909a_0
-  - libssh2=1.9.0=hab1572f_2
+  - libssh2=1.9.0=hab1572f_4
   - libstdcxx-ng=9.2.0=hdf63c60_2
   - mako=1.1.0=py_0
   - markupsafe=1.1.1=py38h1e0a361_1
   - mistune=0.8.4=py38h1e0a361_1001
   - nbconvert=5.6.1=py38h32f6830_1
-  - nbformat=5.0.6=py_0
+  - nbformat=5.0.7=py_0
   - nbresuse=0.3.3=py_0
-  - ncurses=6.1=hf484d3e_1002
-  - notebook=6.0.3=py38h32f6830_0
+  - ncurses=6.2=he1b5a44_1
+  - notebook=6.0.3=py38h32f6830_1
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
   - openssl=1.1.1g=h516909a_0
   - packaging=20.4=pyh9f0ad1d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.9.2.1=0
+  - pandoc=2.10.1=h516909a_0
   - pandocfilters=1.4.2=py_1
-  - parso=0.7.0=pyh9f0ad1d_0
+  - parso=0.7.1=pyh9f0ad1d_0
   - pexpect=4.8.0=py38h32f6830_1
   - pickleshare=0.7.5=py38h32f6830_1001
   - pip=20.1.1=py_1
   - prometheus_client=0.8.0=pyh9f0ad1d_0
-  - prompt-toolkit=3.0.5=py_0
-  - psutil=5.7.0=py38h1e0a361_1
+  - prompt-toolkit=3.0.5=py_1
+  - psutil=5.7.2=py38h1e0a361_0
   - ptyprocess=0.6.0=py_1001
-  - pycparser=2.20=py_0
-  - pycurl=7.43.0.5=py38h16ce93b_0
+  - pycparser=2.20=pyh9f0ad1d_2
+  - pycurl=7.43.0.5=py38h4400d41_2
   - pygments=2.6.1=py_0
   - pyjwt=1.7.1=py_0
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
   - pyrsistent=0.16.0=py38h1e0a361_0
   - pysocks=1.7.1=py38h32f6830_1
-  - python=3.8.3=cpython_he5300dc_0
+  - python=3.8.5=h425cb1d_1_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
   - python-json-logger=0.1.11=py_0
   - python_abi=3.8=1_cp38
   - pyzmq=19.0.1=py38ha71036d_0
-  - readline=8.0=hf8c457e_0
-  - requests=2.23.0=pyh8c360ce_2
+  - readline=8.0=he28a2e2_2
+  - requests=2.24.0=pyh9f0ad1d_0
   - ruamel.yaml=0.16.6=py38h1e0a361_1
   - ruamel.yaml.clib=0.2.0=py38h1e0a361_1
   - send2trash=1.5.0=py_0
-  - setuptools=47.1.1=py38h32f6830_0
+  - setuptools=49.2.0=py38h32f6830_0
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlalchemy=1.3.17=py38h1e0a361_0
-  - sqlite=3.30.1=hcee41ef_0
+  - sqlalchemy=1.3.18=py38h1e0a361_0
+  - sqlite=3.32.3=hcee41ef_1
   - terminado=0.8.3=py38h32f6830_1
   - testpath=0.4.4=py_0
   - tk=8.6.10=hed695b0_0
   - tornado=6.0.4=py38h1e0a361_1
   - traitlets=4.3.3=py38h32f6830_1
-  - urllib3=1.25.9=py_0
-  - wcwidth=0.2.3=pyh9f0ad1d_0
+  - urllib3=1.25.10=py_0
+  - wcwidth=0.2.5=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
   - wheel=0.34.2=py_1
-  - widgetsnbextension=3.5.1=py38_0
-  - xz=5.2.5=h516909a_0
+  - widgetsnbextension=3.5.1=py38h32f6830_1
+  - xz=5.2.5=h516909a_1
   - zeromq=4.3.2=he1b5a44_2
   - zipp=3.1.0=py_0
   - zlib=1.2.11=h516909a_1006

--- a/repo2docker/buildpacks/conda/environment.py-3.8.yml
+++ b/repo2docker/buildpacks/conda/environment.py-3.8.yml
@@ -1,9 +1,9 @@
 # AUTO GENERATED FROM environment.yml, DO NOT MANUALLY MODIFY
-# Generated on 2020-06-02 18:12:32 UTC
+# Generated on 2020-07-25 17:17:57 UTC
 dependencies:
 - python=3.8.*
 - ipywidgets==7.5.1
-- jupyterlab==1.2.6
+- jupyterlab==2.2.0
 - jupyterhub-singleuser==1.1.0
 - nbconvert==5.6.1
 - nbresuse==0.3.3

--- a/repo2docker/buildpacks/conda/environment.yml
+++ b/repo2docker/buildpacks/conda/environment.yml
@@ -1,7 +1,7 @@
 dependencies:
   - python=3.7
   - ipywidgets==7.5.1
-  - jupyterlab==1.2.6
+  - jupyterlab==2.2.0
   - jupyterhub-singleuser==1.1.0
   - nbconvert==5.6.1
   - nbresuse==0.3.3


### PR DESCRIPTION
I couldn't see any blockers in https://github.com/jupyter/repo2docker/issues/724 to upgrading to JupyterLab 2.0. I've started running into new extensions only work with jupyterlab 2 so I thought I'd open this to restart the discussion.

Closes https://github.com/jupyter/repo2docker/issues/724